### PR TITLE
chore: use the build leader for semantic release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script: npm test
 jobs:
   include:
     - stage: npm release
-      node_js: "6"
+      node_js: "8" # This *has* to be the "build leader"
       script: skip
       before_script: # Don't need virtualenv for release, so skip it
       after_success:


### PR DESCRIPTION
Semantic Release requires us to use the same Node version as the so called "build leader" (the first job).