### PR TITLE
chore: hack semantic release to play nice with Travis build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
       script: skip
       before_script: # Don't need virtualenv for release, so skip it
       after_success:
-        - npm run semantic-release
+        - TRAVIS_JOB_NUMBER=WORKAROUND.1 npm run semantic-release
 branches:
   only:
     - master


### PR DESCRIPTION
Semantic release does not play well with Travis build stages, so I'm trying out a hack.

See: https://github.com/semantic-release/travis-deploy-once/blob/master/src.js#L10