### PR TITLE
feat: allow the command to be overridden via options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,10 +5,12 @@ module.exports = {
   inspect: inspect,
 };
 
-function inspect(root, targetFile, args) {
+function inspect(root, targetFile, args, options) {
+  if (!options) { options = {}; }
+  var command = options.command || 'python';
   return Promise.all([
-    getMetaData(),
-    getDependencies(root, targetFile, args),
+    getMetaData(command, root),
+    getDependencies(command, root, targetFile, args),
   ])
   .then(function (result) {
     return {
@@ -18,8 +20,8 @@ function inspect(root, targetFile, args) {
   });
 }
 
-function getMetaData() {
-  return subProcess.execute('python', ['--version'])
+function getMetaData(command, root) {
+  return subProcess.execute(command, ['--version'], { cwd: root })
   .then(function (output) {
     return {
       name: 'snyk-python-plugin',
@@ -28,10 +30,10 @@ function getMetaData() {
   });
 }
 
-function getDependencies(root, targetFile, args) {
+function getDependencies(command, root, targetFile, args) {
   return subProcess.execute(
-    'python',
-    buildArgs(root, targetFile, args),
+    command,
+    buildArgs(targetFile, args),
     { cwd: root }
   )
   .then(function (output) {
@@ -48,7 +50,7 @@ function getDependencies(root, targetFile, args) {
   });
 }
 
-function buildArgs(root, targetFile, extraArgs) {
+function buildArgs(targetFile, extraArgs) {
   var args = [path.resolve(__dirname, '../plug/pip_resolve.py')];
   if (targetFile) { args.push(targetFile); }
   if (extraArgs) { args.push(extraArgs); }


### PR DESCRIPTION
### Why

We need the ability to prefix the underlying system call, for example:
```
source ./venv/bin/activate && python
```
(for virtualenv support)