### PR TITLE
feat: change the API for inspect()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,12 +5,12 @@ module.exports = {
   inspect: inspect,
 };
 
-function inspect(root, targetFile, args, options) {
+function inspect(root, targetFile, options) {
   if (!options) { options = {}; }
   var command = options.command || 'python';
   return Promise.all([
     getMetaData(command, root),
-    getDependencies(command, root, targetFile, args),
+    getDependencies(command, root, targetFile, options.args),
   ])
   .then(function (result) {
     return {

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -95,7 +95,7 @@ test('uses provided exec command', function (t) {
   execute.onSecondCall().returns(Promise.resolve('{}'));
   t.teardown(execute.restore);
 
-  return plugin.inspect('.', 'requirements.txt', null, {
+  return plugin.inspect('.', 'requirements.txt', {
     command: command,
   })
   .then(function () {


### PR DESCRIPTION
inspect() now gets three parameters:
- root - same as before
- targetFile - same as before
- options - a javascript object (nullable), e.g.:
{
   command: 'python',
   args: '-- some-command',
}