### PR TITLE
feat: supporting args as an array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,10 @@ module.exports = {
   inspect: inspect,
 };
 
+module.exports.__tests = {
+  buildArgs: buildArgs,
+};
+
 function inspect(root, targetFile, options) {
   if (!options) { options = {}; }
   var command = options.command || 'python';
@@ -54,6 +58,6 @@ function getDependencies(command, root, targetFile, args) {
 function buildArgs(targetFile, extraArgs) {
   var args = [path.resolve(__dirname, '../plug/pip_resolve.py')];
   if (targetFile) { args.push(targetFile); }
-  if (extraArgs) { args.push(extraArgs); }
+  if (extraArgs) { args = args.concat(extraArgs); }
   return args;
 }

--- a/test/python-plugin.test.js
+++ b/test/python-plugin.test.js
@@ -1,0 +1,26 @@
+var test = require('tap').test;
+var plugin = require('../lib').__tests;
+
+test('check build args with array', function (t) {
+  var result = plugin.buildArgs('requirements.txt', [
+    '-argOne',
+    '-argTwo',
+  ]);
+  t.match(result[0], /.*\/plug\/pip_resolve\.py/);
+  t.deepEqual(result.slice(1), [
+    'requirements.txt',
+    '-argOne',
+    '-argTwo',
+  ]);
+  t.end();
+});
+
+test('check build args with string', function (t) {
+  var result = plugin.buildArgs('requirements.txt', '-argOne -argTwo');
+  t.match(result[0], /.*\/plug\/pip_resolve\.py/);
+  t.deepEqual(result.slice(1), [
+    'requirements.txt',
+    '-argOne -argTwo',
+  ]);
+  t.end();
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Double-dash arguments are now sent as an array of strings, split by spaces.
Supports older, string-string arguments as well, so no breaking change here.