### PR TITLE
feat: option to allow a requirement to be missing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,8 @@ function inspect(root, targetFile, options) {
   var command = options.command || 'python';
   return Promise.all([
     getMetaData(command, root),
-    getDependencies(command, root, targetFile, options.args),
+    getDependencies(
+      command, root, targetFile, options.allowMissing, options.args),
   ])
   .then(function (result) {
     return {
@@ -34,10 +35,10 @@ function getMetaData(command, root) {
   });
 }
 
-function getDependencies(command, root, targetFile, args) {
+function getDependencies(command, root, targetFile, allowMissing, args) {
   return subProcess.execute(
     command,
-    buildArgs(targetFile, args),
+    buildArgs(targetFile, allowMissing, args),
     { cwd: root }
   )
   .then(function (output) {
@@ -55,9 +56,10 @@ function getDependencies(command, root, targetFile, args) {
   });
 }
 
-function buildArgs(targetFile, extraArgs) {
+function buildArgs(targetFile, allowMissing, extraArgs) {
   var args = [path.resolve(__dirname, '../plug/pip_resolve.py')];
   if (targetFile) { args.push(targetFile); }
+  if (allowMissing) { args.push('--allow-missing'); }
   if (extraArgs) { args = args.concat(extraArgs); }
   return args;
 }

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -119,6 +119,30 @@ test('deps not installed', function (t) {
   });
 });
 
+test('deps not installed, but with allowMissing option', function (t) {
+  chdirWorkspaces('pip-app-deps-not-installed');
+  return plugin.inspect('.', 'requirements.txt', {allowMissing: true})
+  .then(function (result) {
+    var plugin = result.plugin;
+    var pkg = result.package;
+
+    t.test('plugin', function (t) {
+      t.ok(plugin, 'plugin');
+      t.equal(plugin.name, 'snyk-python-plugin', 'name');
+      t.match(plugin.runtime, 'Python', 'runtime');
+      t.end();
+    });
+
+    t.test('package', function (t) {
+      t.ok(pkg, 'package');
+      t.equal(pkg.name, 'pip-app-deps-not-installed', 'name');
+      t.equal(pkg.version, '0.0.0', 'version');
+      t.same(pkg.from, ['pip-app-deps-not-installed@0.0.0'], 'from self');
+      t.end();
+    });
+  });
+});
+
 test('uses provided exec command', function (t) {
   var command = 'echo';
   var execute = sinon.stub(subProcess, 'execute');

--- a/test/python-plugin.test.js
+++ b/test/python-plugin.test.js
@@ -2,7 +2,7 @@ var test = require('tap').test;
 var plugin = require('../lib').__tests;
 
 test('check build args with array', function (t) {
-  var result = plugin.buildArgs('requirements.txt', [
+  var result = plugin.buildArgs('requirements.txt', false, [
     '-argOne',
     '-argTwo',
   ]);
@@ -15,11 +15,37 @@ test('check build args with array', function (t) {
   t.end();
 });
 
-test('check build args with string', function (t) {
-  var result = plugin.buildArgs('requirements.txt', '-argOne -argTwo');
+test('check build args with array & allowMissing', function (t) {
+  var result = plugin.buildArgs('requirements.txt', true, [
+    '-argOne',
+    '-argTwo',
+  ]);
   t.match(result[0], /.*\/plug\/pip_resolve\.py/);
   t.deepEqual(result.slice(1), [
     'requirements.txt',
+    '--allow-missing',
+    '-argOne',
+    '-argTwo',
+  ]);
+  t.end();
+});
+
+test('check build args with string', function (t) {
+  var result = plugin.buildArgs('requirements.txt', false, '-argOne -argTwo');
+  t.match(result[0], /.*\/plug\/pip_resolve\.py/);
+  t.deepEqual(result.slice(1), [
+    'requirements.txt',
+    '-argOne -argTwo',
+  ]);
+  t.end();
+});
+
+test('check build args with string & allowMissing', function (t) {
+  var result = plugin.buildArgs('requirements.txt', true, '-argOne -argTwo');
+  t.match(result[0], /.*\/plug\/pip_resolve\.py/);
+  t.deepEqual(result.slice(1), [
+    'requirements.txt',
+    '--allow-missing',
     '-argOne -argTwo',
   ]);
   t.end();


### PR DESCRIPTION
passing `allowMissing: true` in the `options` argument to `inspect()`, will not raise an exception in case a required package is not installed.