### PR TITLE
fix: handle cyclic deps

### DIFF
--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -115,6 +115,46 @@ test('inspect', function (t) {
         },
       }, 'django-select2 looks ok');
 
+      t.match(pkg.dependencies['irc'], {
+        name: 'irc',
+        version: '16.2',
+        from: [
+          "pip-app@0.0.0",
+          "irc@16.2"
+        ],
+        dependencies: {
+          'more-itertools': {},
+          'jaraco.functools': {},
+          'jaraco.collections': {
+            dependencies: {
+              'jaraco.text': {},
+            }
+          },
+          'jaraco.text': {
+            dependencies: {
+              'jaraco.collections': {}
+            }
+          },
+        }
+      }, 'irc ok, even though it has a cyclic dep, yay!')
+
+      t.match(pkg.dependencies['testtools'], {
+        name: 'testtools',
+        version: '2.3.0',
+        from: [
+          "pip-app@0.0.0",
+          "testtools@2.3.0"
+        ],
+        dependencies: {
+          'pbr': {},
+          'extras': {},
+          'fixtures': {},
+          'unittest2': {},
+          'traceback2': {},
+          'python-mimeparse': {},
+        }
+      }, 'testtools ok, even though it\'s cyclic, yay!')
+
       t.end();
     });
 

--- a/test/workspaces/pip-app/requirements.txt
+++ b/test/workspaces/pip-app/requirements.txt
@@ -2,3 +2,5 @@ Jinja2==2.7.2
 Django==1.6.1
 python-etcd==0.4.5
 Django-Select2==6.0.1 # this version installs with lowercase so it catches a previous bug in pip_resolve.py
+irc==16.2 # this has a cyclic dependecy (interanl jaraco.text <==> jaraco.collections)
+testtools==2.3.0 # this has a cycle (fixtures ==> testtols)


### PR DESCRIPTION
before this bugfix some packages like `jarico.text==1.9.2` and `testtools==2.3.0` caused an infinite recursion in the `pip_resolve.py`