### PR TITLE
fix: handle more per-requirements params

### DIFF
--- a/plug/requirements/requirement.py
+++ b/plug/requirements/requirement.py
@@ -196,8 +196,10 @@ class Requirement(object):
             # Delegate to pkg_resources and hope for the best
             req.specifier = True
 
-            # an optional --hash param is not part of the req specifier
-            line = re.sub('\s*--hash=\S+', '', line)
+            # an optional per-requirement param is not part of the req specifier
+            #   see https://pip.pypa.io/en/stable/reference/pip_install/#per-requirement-overrides
+            #   and https://pip.pypa.io/en/stable/reference/pip_install/#hash-checking-mode
+            line = re.sub('\s*--[a-z-]+=\S+', '', line)
 
             pkg_req = Req.parse(line)
             req.name = pkg_req.unsafe_name

--- a/test/workspaces/pip-app-with-options/requirements.txt
+++ b/test/workspaces/pip-app-with-options/requirements.txt
@@ -2,4 +2,7 @@
 MarkupSafe==1.0 --hash=sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665 \
     --hash=sha256:abcd \
     --hash=sha256:0123 # a comment
-dnspython==1.13.0 --hash=sha256:80f89881b402fc3b931a936111b43bcfe3abd8b0005d27e50e3c5fb59f7260f8
+dnspython==1.13.0 \
+    --hash=sha256:80f89881b402fc3b931a936111b43bcfe3abd8b0005d27e50e3c5fb59f7260f8 \
+    --install-option="--no-compile"
+


### PR DESCRIPTION
until now it supported `--hashes`, but more exist e.g.:
https://pip.pypa.io/en/stable/reference/pip_install/#per-requirement-overrides

before the fix, `pip-resolve.py` would throw an exception if such a line
is encountered
