### PR TITLE
fix: prevent crash when editable fragment references a tag

### DIFF
--- a/plug/requirements/fragment.py
+++ b/plug/requirements/fragment.py
@@ -1,3 +1,5 @@
+# MODIFIED - Replace/Update with care
+
 import re
 
 # Copied from pip
@@ -14,7 +16,7 @@ def parse_fragment(fragment_string):
 
     try:
         return dict(
-            key_value_string.split('=')
+            key_value_string.split('==')[0].split('=')
             for key_value_string in fragment_string.split('&')
         )
     except ValueError:

--- a/test/workspaces/pip-app-deps-editable/requirements.txt
+++ b/test/workspaces/pip-app-deps-editable/requirements.txt
@@ -1,3 +1,3 @@
--e git+https://github.com/snyk-fixtures/python-pypi-package-simple#egg=simple
+git+https://github.com/snyk-fixtures/python-pypi-package-simple@v1.0.0#egg=simple==v1.0.0
 -e git+https://github.com/snyk-fixtures/python-pypi-package-sample-subdir#egg=sample&subdirectory=subdir
 posix_ipc==1.0.0


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

#### What does this PR do?

- prevents a crash when an editable fragment references a tag
- fragment parser was crashing on things like `#egg=simple==v1.0.0`
- note: removed the `-e` from the test fixture to force the issue