### PR TITLE
fix: add python files as Zeit assets, dump them to disk and run

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 var path = require('path');
 var subProcess = require('./sub-process');
+var fs = require('fs');
+var tmp = require('tmp');
 
 module.exports = {
   inspect: inspect,
@@ -35,16 +37,88 @@ function getMetaData(command, root) {
   });
 }
 
-function getDependencies(command, root, targetFile, allowMissing, args) {
+// Hack:
+// We're using Zeit assets feature in order to support Python and Go testing 
+// within a binary release. By doing "path.join(__dirname, 'PATH'), Zeit adds
+// PATH file auto to the assets. Sadly, Zeit doesn't support (as far as I
+// understand) adding a full folder as an asset, and this is why we're adding
+// the required files this way. In addition, Zeit doesn't support 
+// path.resolve(), and this is why I'm using path.join()
+function createAssets(){
+  assets = [];
+  assets.push(path.join(__dirname, '../plug/pip_resolve.py'));
+  assets.push(path.join(__dirname, '../plug/distPackage.py'));
+  assets.push(path.join(__dirname, '../plug/package.py'));
+  assets.push(path.join(__dirname, '../plug/reqPackage.py'));
+  assets.push(path.join(__dirname, '../plug/utils.py'));
+
+  assets.push(path.join(__dirname, '../plug/requirements/fragment.py'));
+  assets.push(path.join(__dirname, '../plug/requirements/parser.py'));
+  assets.push(path.join(__dirname, '../plug/requirements/requirement.py'));
+  assets.push(path.join(__dirname, '../plug/requirements/vcs.py'));
+  assets.push(path.join(__dirname, '../plug/requirements/__init__.py'));
+
+  return assets;
+}
+
+function writeFile(writeFilePath, contents) {
+  var dirPath = path.dirname(writeFilePath);
+  if (!fs.existsSync(dirPath))
+  {
+    fs.mkdirSync(dirPath);
+  }
+  fs.writeFileSync(writeFilePath, contents);
+}
+
+function getFilePathRelativeToDumpDir(filePath) {
+  var pathParts = filePath.split('\\plug\\');
+
+  // Windows
+  if (pathParts.length > 1)
+  {
+    return pathParts[1];
+  }
+
+  // Unix
+  pathParts = filePath.split('/plug/');
+  return pathParts[1];  
+}
+
+function dumpAllFilesInTempDir(tempDirName) {
+  createAssets().forEach(function(currentReadFilePath) {
+    if (!fs.existsSync(currentReadFilePath))
+    {
+      throw new Error('The file `' + currentReadFilePath + '` is missing');
+    }
+    
+    var relFilePathToDumpDir = 
+      getFilePathRelativeToDumpDir(currentReadFilePath);
+    
+    var writeFilePath = path.join(tempDirName, relFilePathToDumpDir);
+
+    var contents = fs.readFileSync(currentReadFilePath);
+    writeFile(writeFilePath, contents);
+  });
+}
+
+function getDependencies(command, root, targetFile, allowMissing, args) {  
+  var tempDirObj = tmp.dirSync({
+    unsafeCleanup: true
+  });
+
+  dumpAllFilesInTempDir(tempDirObj.name);
+
   return subProcess.execute(
     command,
-    buildArgs(targetFile, allowMissing, args),
+    buildArgs(targetFile, allowMissing, tempDirObj.name, args),
     { cwd: root }
   )
   .then(function (output) {
+    tempDirObj.removeCallback();
     return JSON.parse(output);
   })
   .catch(function (error) {
+    tempDirObj.removeCallback();
     if (typeof error === 'string') {
       if (error.indexOf('Required package missing') !== -1) {
         // TODO: this should be checked in the CLI, not here
@@ -56,8 +130,10 @@ function getDependencies(command, root, targetFile, allowMissing, args) {
   });
 }
 
-function buildArgs(targetFile, allowMissing, extraArgs) {
-  var args = [path.resolve(__dirname, '../plug/pip_resolve.py')];
+function buildArgs(targetFile, allowMissing, tempDirPath, extraArgs) {
+
+  var pathToRun = path.join(tempDirPath, 'pip_resolve.py');
+  var args = [pathToRun];
   if (targetFile) { args.push(targetFile); }
   if (allowMissing) { args.push('--allow-missing'); }
   if (extraArgs) { args = args.concat(extraArgs); }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   },
   "author": "snyk.io",
   "license": "Apache-2.0",
+  "dependencies": {
+    "tmp": "0.0.33"
+  },
   "devDependencies": {
     "jscs": "^3.0.7",
     "semantic-release": "^6.3.6",

--- a/test/python-plugin.test.js
+++ b/test/python-plugin.test.js
@@ -2,7 +2,7 @@ var test = require('tap').test;
 var plugin = require('../lib').__tests;
 
 test('check build args with array', function (t) {
-  var result = plugin.buildArgs('requirements.txt', false, [
+  var result = plugin.buildArgs('requirements.txt', false, "../plug", [
     '-argOne',
     '-argTwo',
   ]);
@@ -16,7 +16,7 @@ test('check build args with array', function (t) {
 });
 
 test('check build args with array & allowMissing', function (t) {
-  var result = plugin.buildArgs('requirements.txt', true, [
+  var result = plugin.buildArgs('requirements.txt', true, "../plug", [
     '-argOne',
     '-argTwo',
   ]);
@@ -31,7 +31,7 @@ test('check build args with array & allowMissing', function (t) {
 });
 
 test('check build args with string', function (t) {
-  var result = plugin.buildArgs('requirements.txt', false, '-argOne -argTwo');
+  var result = plugin.buildArgs('requirements.txt', false, "../plug", '-argOne -argTwo');
   t.match(result[0], /.*\/plug\/pip_resolve\.py/);
   t.deepEqual(result.slice(1), [
     'requirements.txt',
@@ -41,7 +41,7 @@ test('check build args with string', function (t) {
 });
 
 test('check build args with string & allowMissing', function (t) {
-  var result = plugin.buildArgs('requirements.txt', true, '-argOne -argTwo');
+  var result = plugin.buildArgs('requirements.txt', true, "../plug", '-argOne -argTwo');
   t.match(result[0], /.*\/plug\/pip_resolve\.py/);
   t.deepEqual(result.slice(1), [
     'requirements.txt',


### PR DESCRIPTION
#### What does this PR do?
Adding assets to the binary release (by path.join(__dirname,PATH))
Dump all of the files to the disk (temp folder)
Execute the python script (pip_resolve.py) from the temp dir

This is the new behaviour of the plugin regarding if it run as binary \ not

#### How should this be manually tested?
No auto tests were added.
Manually tested "pkg ." (Zeit) with node 8 on the following os:
-Mac - python27
-Windows - python27 + python36

#### Any background context you want to provide?
Trying to avoid creating a docker img for python, we realised it might be faster to use Zeit binary release as a proper solution