### PR TITLE
chore: add test/manual.js for manual invocation

### DIFF
--- a/test/manual.js
+++ b/test/manual.js
@@ -1,0 +1,15 @@
+var plugin = require('../lib');
+
+function main() {
+  var targetFile = process.argv[2];
+  var root = process.argv[3] || '.';
+
+  plugin.inspect(root, targetFile).then(function (result) {
+    console.log(JSON.stringify(result, null, 2));
+  }).catch(function (error) {
+    console.log('Error:', error.stack);
+  });
+
+};
+
+main();


### PR DESCRIPTION
useful to run the plugin standalone, e.g.

```bash
$ cd <python-proj>
$ node <path to snyk-python-plugin>/test/manual.js requirements.txt
```