### PR TITLE
feat: support dev dependencies in pipenv projects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ module.exports.__tests = {
 function inspect(root, targetFile, options) {
   if (!options) { options = {}; }
   var command = options.command || 'python';
+  var isDevDeps = !!(options.dev || false);
   var baseargs = [];
 
   if (path.basename(targetFile) === 'Pipfile') {
@@ -29,7 +30,8 @@ function inspect(root, targetFile, options) {
   return Promise.all([
     getMetaData(command, baseargs, root),
     getDependencies(
-      command, baseargs, root, targetFile, options.allowMissing, options.args),
+      command, baseargs, root, targetFile,
+      options.allowMissing, isDevDeps, options.args),
   ])
   .then(function (result) {
     return {
@@ -124,7 +126,7 @@ function dumpAllFilesInTempDir(tempDirName) {
 }
 
 function getDependencies(command, baseargs, root, targetFile,
-                         allowMissing, args) {
+                         allowMissing, isDevDeps, args) {
   var tempDirObj = tmp.dirSync({
     unsafeCleanup: true
   });
@@ -134,7 +136,8 @@ function getDependencies(command, baseargs, root, targetFile,
   return subProcess.execute(
     command,
     [].concat(baseargs,
-              buildArgs(targetFile, allowMissing, tempDirObj.name, args)),
+              buildArgs(targetFile, allowMissing, tempDirObj.name, isDevDeps,
+                        args)),
     { cwd: root }
   )
   .then(function (output) {
@@ -151,18 +154,24 @@ function getDependencies(command, baseargs, root, targetFile,
         }
         throw new Error(errMsg);
       }
+      else if (error.indexOf('dev dependencies are not supported') !== -1) {
+        var errMsg = /Exception:\s*(.*?)(?:\n|$)/.exec(error)[1];
+        throw new Error(
+          'Error: ' + errMsg.charAt(0).toUpperCase() + errMsg.slice(1));
+      }
       throw new Error(error);
     }
     throw error;
   });
 }
 
-function buildArgs(targetFile, allowMissing, tempDirPath, extraArgs) {
-
+function buildArgs(targetFile, allowMissing, tempDirPath, isDevDeps,
+                   extraArgs) {
   var pathToRun = path.join(tempDirPath, 'pip_resolve.py');
   var args = [pathToRun];
   if (targetFile) { args.push(targetFile); }
   if (allowMissing) { args.push('--allow-missing'); }
+  if (isDevDeps) { args.push('--dev-deps'); }
   if (extraArgs) { args = args.concat(extraArgs); }
   return args;
 }

--- a/test/python-plugin.test.js
+++ b/test/python-plugin.test.js
@@ -2,7 +2,7 @@ var test = require('tap').test;
 var plugin = require('../lib').__tests;
 
 test('check build args with array', function (t) {
-  var result = plugin.buildArgs('requirements.txt', false, "../plug", [
+  var result = plugin.buildArgs('requirements.txt', false, "../plug", false, [
     '-argOne',
     '-argTwo',
   ]);
@@ -16,7 +16,7 @@ test('check build args with array', function (t) {
 });
 
 test('check build args with array & allowMissing', function (t) {
-  var result = plugin.buildArgs('requirements.txt', true, "../plug", [
+  var result = plugin.buildArgs('requirements.txt', true, "../plug", false, [
     '-argOne',
     '-argTwo',
   ]);
@@ -30,8 +30,39 @@ test('check build args with array & allowMissing', function (t) {
   t.end();
 });
 
+test('check build args with array & devDeps', function (t) {
+  var result = plugin.buildArgs('requirements.txt', false, "../plug", true, [
+    '-argOne',
+    '-argTwo',
+  ]);
+  t.match(result[0], /.*\/plug\/pip_resolve\.py/);
+  t.deepEqual(result.slice(1), [
+    'requirements.txt',
+    '--dev-deps',
+    '-argOne',
+    '-argTwo',
+  ]);
+  t.end();
+});
+
+test('check build args with array & allowMissing & devDeps', function (t) {
+  var result = plugin.buildArgs('requirements.txt', true, "../plug", true, [
+    '-argOne',
+    '-argTwo',
+  ]);
+  t.match(result[0], /.*\/plug\/pip_resolve\.py/);
+  t.deepEqual(result.slice(1), [
+    'requirements.txt',
+    '--allow-missing',
+    '--dev-deps',
+    '-argOne',
+    '-argTwo',
+  ]);
+  t.end();
+});
+
 test('check build args with string', function (t) {
-  var result = plugin.buildArgs('requirements.txt', false, "../plug", '-argOne -argTwo');
+  var result = plugin.buildArgs('requirements.txt', false, "../plug", false, '-argOne -argTwo');
   t.match(result[0], /.*\/plug\/pip_resolve\.py/);
   t.deepEqual(result.slice(1), [
     'requirements.txt',
@@ -41,7 +72,7 @@ test('check build args with string', function (t) {
 });
 
 test('check build args with string & allowMissing', function (t) {
-  var result = plugin.buildArgs('requirements.txt', true, "../plug", '-argOne -argTwo');
+  var result = plugin.buildArgs('requirements.txt', true, "../plug", false, '-argOne -argTwo');
   t.match(result[0], /.*\/plug\/pip_resolve\.py/);
   t.deepEqual(result.slice(1), [
     'requirements.txt',


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Add support for testing dev dependencies via `snyk test --dev` in projects using pipenv.

#### Where should the reviewer start?
`inspect()` in `index.js`, follow the new `isDevDeps` flag linearly through the code into `pip_resolve.py`.

#### How should this be manually tested?
Run `snyk test --dev` in Python projects using pipenv (`Pipfile`) and pip (`requirements.txt`), e.g. those in `test/workspaces`. It should successfully analyze only the dev dependencies for pipenv, and fail with an informative error for pip.

#### Any background context you want to provide?
`Pipfile` natively has two separate sections for dependencies, `packages` and `dev-packages`. See [the docs](https://github.com/pypa/pipfile) for more info.

#### What are the relevant tickets?
SC-5774

#### Screenshots


#### Additional questions
