### PR TITLE
test: test with multiple versions of Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,31 @@ node_js:
   - "6"
   - "4"
 env:
-  - PIP_VER=9.0.3
-  - PIP_VER=10.0.0
+  - PIP_VER=9.0.3   PYTHON_VER=2.7
+  - PIP_VER=9.0.3   PYTHON_VER=3.5
+  - PIP_VER=9.0.3   PYTHON_VER=3.6
+#  - PIP_VER=9.0.3   PYTHON_VER=3.7  # missing in Travis's old version of pyenv
+  - PIP_VER=10.0.0  PYTHON_VER=2.7
+  - PIP_VER=10.0.0  PYTHON_VER=3.5
+  - PIP_VER=10.0.0  PYTHON_VER=3.6
+#  - PIP_VER=10.0.0  PYTHON_VER=3.7  # missing in Travis's old version of pyenv
 cache:
   directories:
     - node_modules
 before_script:
+  # Find the latest specific release of the desired Python version, e.g. 3.6.6.
+  - export PYTHON_VER_FULL=`pyenv install --list | grep -v 'Available versions' | awk '{$1=$1};1' | grep "^$PYTHON_VER\.[0-9]\+$" | tail -1`
+  - echo $PYTHON_VER_FULL
+  # Install the specific release of Python if it isn't already installed
+  - pyenv install -s $PYTHON_VER_FULL
+  - pyenv shell $PYTHON_VER_FULL
+  - python --version
   - export PATH=$HOME/.local/bin:$PATH
   - pip install --user pip==$PIP_VER
+  # Call `pyenv rehash` to avoid issues after installing a new version of pip.
+  # see: https://github.com/pyenv/pyenv/issues/1141#issuecomment-383092896
+  - pyenv rehash
+  - pip --version
   - pip install --user -r dev-requirements.txt --disable-pip-version-check
 script: npm test
 jobs:


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
On Travis CI, add testing with various 3.x versions Python in addition to 2.7.

#### Where should the reviewer start?
`.travis.yml` and the Travis build logs for this PR.

#### How should this be manually tested?
Trigger another Travis build.

#### Any background context you want to provide?
This uses pyenv to install different versions of Python. pyenv comes pre-installed on Travis when using `dist: trusty` as we do in our `.travis.yml`. However, this version of pyenv is currently a bit old, and doesn't include the latest Python releases, e.g. 3.7.0, 3.6.6, 3.5.5 and 2.7.15. I've made a bit of extra effort here to use the latest available release of each _major.minor_ version of Python we'd like to test with.

On a different note, simply adding the following to `.travis.yml` doesn't work, unfortunately:
```yaml
python:
  - "2.7"
  - "3.5"
  - "3.6"
```

It is also not possible to have Travis generate the Cartesian product from sets of different values for several environment variables, i.e. the following or anything equivalent doesn't do what we want:
```yaml
env:
  - PIP_VER=9.0.3
  - PIP_VER=10.0.0
  - PYTHON_VER=2.7
  - PYTHON_VER=3.5
  - PYTHON_VER=3.6
```

The solution here is simply to manually spell out all of the different combinations to test.

#### What are the relevant tickets?


#### Screenshots


#### Additional questions
