### PR TITLE
Fix/pipenv targetfile

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ function inspect(root, targetFile, options) {
   }
 
   return Promise.all([
-    getMetaData(command, baseargs, root),
+    getMetaData(command, baseargs, root, targetFile),
     getDependencies(
       command,
       baseargs,
@@ -50,7 +50,7 @@ function inspect(root, targetFile, options) {
     });
 }
 
-function getMetaData(command, baseargs, root) {
+function getMetaData(command, baseargs, root, targetFile) {
   return subProcess.execute(
     command,
     [].concat(baseargs, ['--version']),
@@ -60,6 +60,9 @@ function getMetaData(command, baseargs, root) {
       return {
         name: 'snyk-python-plugin',
         runtime: output.replace('\n', ''),
+        // specify targetFile only in case of Pipfile
+        targetFile:
+          (path.basename(targetFile) === 'Pipfile') ? targetFile : undefined,
       };
     });
 }

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -126,6 +126,7 @@ test('inspect', function (t) {
         t.ok(plugin, 'plugin');
         t.equal(plugin.name, 'snyk-python-plugin', 'name');
         t.match(plugin.runtime, 'Python', 'runtime');
+        t.notOk(plugin.targetFile, 'no targetfile for requirements.txt');
         t.end();
       });
 
@@ -468,7 +469,10 @@ test('inspect Pipfile', function (t) {
       return plugin.inspect('.', 'Pipfile');
     })
     .then(function (result) {
+      var plugin = result.plugin;
       var pkg = result.package;
+
+      t.equal(plugin.targetFile, 'Pipfile', 'Pipfile targetfile');
 
       t.test('package dependencies', function (t) {
         t.notOk(pkg.dependencies['django'], 'django skipped (editable)');


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Prior to this change, `snyk monitor` on a `pipenv` project would generate a snapshot that is identified with a `requirements.txt` file, as this is the default `targetFile` for this plugin.

Fixing this, using `Pipfile` as the `targetFile` for `pipenv` projects.