### PR TITLE
test: python 3.6 covers python 3.5 scenario, removing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,9 @@ node_js:
   - "4"
 env:
   - PIP_VER=9.0.3   PYTHON_VER=2.7
-  - PIP_VER=9.0.3   PYTHON_VER=3.5
   - PIP_VER=9.0.3   PYTHON_VER=3.6
 #  - PIP_VER=9.0.3   PYTHON_VER=3.7  # missing in Travis's old version of pyenv
   - PIP_VER=10.0.0  PYTHON_VER=2.7
-  - PIP_VER=10.0.0  PYTHON_VER=3.5
   - PIP_VER=10.0.0  PYTHON_VER=3.6
 #  - PIP_VER=10.0.0  PYTHON_VER=3.7  # missing in Travis's old version of pyenv
 cache:


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Reducing the length of our CI test suite, as `python 3.6` provides sufficient coverage.