### PR TITLE
feat: just use pkg_resources rather than pip internals

### DIFF
--- a/plug/pip_resolve.py
+++ b/plug/pip_resolve.py
@@ -8,18 +8,15 @@ import utils
 import requirements
 import pipfile
 
-# pip >= 10.0.0 moved all APIs to the _internal package reflecting the fact
-#   that pip does not currently have any public APIs.
-# pip >= 18.0.0 moved the internal API we use deeper to _internal.utils.misc
-# TODO: This is a temporary fix that might not hold again for upcoming releases,
-#   we need a better approach for this.
 try:
-    from pip import get_installed_distributions
+    import pkg_resources
 except ImportError:
-    try :
-        from pip._internal import get_installed_distributions
+    # try using the version vendored by pip
+    try:
+        import pip._vendor.pkg_resources as pkg_resources
     except ImportError:
-        from pip._internal.utils.misc import get_installed_distributions
+        raise ImportError(
+            "Could not import pkg_resources; please install setuptools or pip.")
 
 
 def create_tree_of_packages_dependencies(dist_tree, packages_names, req_file_path, allow_missing=False):
@@ -147,7 +144,7 @@ def create_dependencies_tree_by_req_file_path(requirements_file_path,
                                               allow_missing=False,
                                               dev_deps=False):
     # get all installed packages
-    pkgs = get_installed_distributions(local_only=False, skip=[])
+    pkgs = list(pkg_resources.working_set)
 
     # get all installed packages's distribution object
     dist_index = utils.build_dist_index(pkgs)


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Avoid importing `get_installed_distributions()` from inside pip.

#### Where should the reviewer start?

To see why this is equivalent, see how we are currently calling `get_installed_distributions()` in `pip_resolve.py`, then read the (simple!) source of `get_installed_distributions()` [here](https://github.com/pypa/pip/blob/47b94f19bbe0167cebb92995fc52b80d41b5ba28/src/pip/_internal/utils/misc.py#L340).

#### How should this be manually tested?

`npm run test` (All tests pass!)
