### PR TITLE
test: Filter out deps that don't match required Python markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /node_modules/
 __pycache__/
 *.pyc
+npm-debug.log
+test/.venvs/

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -206,7 +206,6 @@ test('transitive dep not installed, but with allowMissing option',
           t.ok(pkg, 'package');
           t.equal(pkg.name, 'pip-app', 'name');
           t.equal(pkg.version, '0.0.0', 'version');
-          // t.equal(pkg.full, 'pip-app@0.0.0', 'full'); // do we need this?
           t.end();
         });
 
@@ -321,7 +320,7 @@ test('uses provided exec command', function (t) {
     });
 });
 
-test('package name differs from requirement', function (t) {
+test('package name differs from requirement (- vs _)', function (t) {
   return Promise.resolve().then(function () {
     chdirWorkspaces('pip-app-deps-with-dashes');
     var venvCreated = testUtils.ensureVirtualenv('pip-app-deps-with-dashes');
@@ -343,6 +342,30 @@ test('package name differs from requirement', function (t) {
         name: 'posix-ipc',
         version: '1.0.0',
       }, 'posix-ipc looks ok');
+      t.end();
+    });
+});
+
+test('package name differs from requirement (- vs .)', function (t) {
+  t.pass('Not implemented yet');
+  t.end();
+});
+
+test('package installed conditionally based on python version', function (t) {
+  return Promise.resolve().then(function () {
+    chdirWorkspaces('pip-app-with-python-markers');
+    var venvCreated = testUtils.ensureVirtualenv('pip-app-with-python-markers');
+    t.teardown(testUtils.activateVirtualenv('pip-app-with-python-markers'));
+    if (venvCreated) {
+      testUtils.pipInstall();
+    }
+  })
+    .then(function () {
+      return plugin.inspect('.', 'requirements.txt');
+    })
+    .then(function (result) {
+      var pkg = result.package;
+      t.notOk(pkg.dependencies.enum34, 'enum34 dep ignored');
       t.end();
     });
 });

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -370,6 +370,27 @@ test('package installed conditionally based on python version', function (t) {
     });
 });
 
+test('Pipfile package found conditionally based on python version', function (t) {
+  return Promise.resolve().then(function () {
+    chdirWorkspaces('pipfile-markers');
+    var venvCreated = testUtils.ensureVirtualenv('pipfile-markers');
+    t.teardown(testUtils.activateVirtualenv('pipfile-markers'));
+    if (venvCreated) {
+      testUtils.pipInstall();
+    }
+  })
+    .then(function () {
+      return plugin.inspect('.', 'Pipfile');
+    })
+    .then(function (result) {
+      var pkg = result.package;
+      t.notOk(pkg.dependencies.black, 'black dep ignored');
+      t.notOk(pkg.dependencies.stdeb, 'stdeb dep ignored');
+
+      t.end();
+    });
+});
+
 test('package depends on platform', function (t) {
   return Promise.resolve().then(function () {
     chdirWorkspaces('pip-app-deps-conditional');
@@ -446,7 +467,6 @@ test('deps with options', function (t) {
         t.equal(pkg.version, '0.0.0', 'version');
         t.end();
       });
-
       t.test('package dependencies', function (t) {
         t.match(pkg.dependencies.markupsafe, {
           name: 'markupsafe',

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -373,11 +373,7 @@ test('package installed conditionally based on python version', function (t) {
 test('Pipfile package found conditionally based on python version', function (t) {
   return Promise.resolve().then(function () {
     chdirWorkspaces('pipfile-markers');
-    var venvCreated = testUtils.ensureVirtualenv('pipfile-markers');
-    t.teardown(testUtils.activateVirtualenv('pipfile-markers'));
-    if (venvCreated) {
-      testUtils.pipInstall();
-    }
+    t.teardown(testUtils.activateVirtualenv('pip-app'));
   })
     .then(function () {
       return plugin.inspect('.', 'Pipfile');

--- a/test/workspaces/pip-app-with-python-markers/requirements.txt
+++ b/test/workspaces/pip-app-with-python-markers/requirements.txt
@@ -1,0 +1,25 @@
+amqp==2.4.2
+apscheduler==3.6.0
+asn1crypto==0.24.0
+astroid==1.6.6
+atomicwrites==1.3.0
+attrs==19.1.0
+automat==0.7.0
+backports.functools-lru-cache==1.5 ; python_version < '3.2'
+billiard==3.6.0.0
+celery==4.3.0
+certifi==2019.3.9
+cffi==1.12.3
+chardet==3.0.4
+click==7.0
+clickclick==1.2.2
+configparser==3.7.4 ; python_version == '2.7'
+connexion[swagger-ui]==2.2.0
+constantly==15.1.0
+cryptography==2.6.1
+cssselect==1.0.3
+cython==0.29.7
+enum34==1.1.6 ; python_version < '2.6'
+fastavro==0.21.21
+flask-apscheduler==1.11.0
+flask==1.0.2

--- a/test/workspaces/pipfile-markers/Pipfile
+++ b/test/workspaces/pipfile-markers/Pipfile
@@ -1,0 +1,26 @@
+[dev-packages]
+"flake8" = ">=3.3.0,<4"
+sphinx = "<=1.5.5"
+twine = "*"
+sphinx-click = "*"
+click = "*"
+pytest_pypi = {path = "./tests/pytest-pypi", editable = true}
+stdeb = {version="*", markers="sys_platform == 'linux' ; python_version != '3.4"}
+black = {version="*", markers="python_version > '3.6'"}
+pytz = "*"
+towncrier = {git = "https://github.com/hawkowl/towncrier.git", editable = true, ref = "master"}
+parver = "*"
+invoke = "*"
+jedi = "*"
+isort = "*"
+rope = "*"
+passa = {editable = true, git = "https://github.com/sarugaku/passa.git"}
+bs4 = "*"
+
+[packages]
+
+[scripts]
+tests = "bash ./run-tests.sh"
+
+[pipenv]
+allow_prereleases = true


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Introduce filtering out deps based on current Python environment if they don't match based on their Python version markers
#### Where should the reviewer start?
Run this locally on  https://github.com/lili2311/helios

#### How should this be manually tested?
- in plugin dir `npm link` 
- in the snyk CLI dir `npm link snyk-python-plugin` 
- clone https://github.com/lili2311/helios
- run a local `snyk-dev test` on helios, it should succeeded without any extra options

#### Any background context you want to provide?
The plugin is not taking into account python version markers on dependencies and so we look for them when thy are not installed

