### PR TITLE
Support setup.py files

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -69,6 +69,7 @@ function createAssets() {
     path.join(__dirname, '../pysrc/package.py'),
     path.join(__dirname, '../pysrc/pipfile.py'),
     path.join(__dirname, '../pysrc/reqPackage.py'),
+    path.join(__dirname, '../pysrc/setup_file.py'),
     path.join(__dirname, '../pysrc/utils.py'),
 
     path.join(__dirname, '../pysrc/requirements/fragment.py'),

--- a/pysrc/setup_file.py
+++ b/pysrc/setup_file.py
@@ -1,0 +1,38 @@
+import distutils.core
+import re
+import setuptools
+
+def parse(setup_py_content):
+    """Parse a setup.py file and extract the arguments passed to the setup method"""
+    # Make the setup method return the arguments that are passed to it
+    def _save_passed_args(**kwargs):
+        return kwargs
+
+    distutils.core.setup = _save_passed_args
+    setuptools.setup = _save_passed_args
+    setup_py_content = setup_py_content.replace("setup(", "passed_arguments = setup(")
+
+    # Fetch the arguments that were passed to the setup.py
+    exec(setup_py_content, globals())
+    return globals()["passed_arguments"]
+
+
+def parse_name_and_version(setup_py_content):
+    """Extract the name and version from a setup.py file"""
+    passed_arguments = parse(setup_py_content)
+    return passed_arguments.get("name"), passed_arguments.get("version")
+
+
+def get_provenance(setup_py_content):
+    """Provenance for a setup.py file is the index of the line that contains `install_requires`"""
+    for index, line in enumerate(setup_py_content.splitlines()):
+        if re.search(r"(packages|install_requires)\s*=", line):
+            return index + 1
+    return -1
+
+
+def parse_requirements(setup_py_content):
+    """Extract the dependencies from a setup.py file"""
+    passed_arguments = parse(setup_py_content)
+    requirements = passed_arguments.get("install_requires", passed_arguments.get("packages", []))
+    return "\n".join(requirements)

--- a/test/workspaces/setup_py-app/setup.py
+++ b/test/workspaces/setup_py-app/setup.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(
+    name="test_package",
+    version="1.0.2",
+    packages=[
+        "Jinja2==2.7.2",
+        "Django==1.6.1",
+        "python-etcd==0.4.5",
+        "Django-Select2==6.0.1",  # this version installs with lowercase so it catches a previous bug in pip_resolve.py
+        "irc==16.2",  # this has a cyclic dependecy (interanl jaraco.text <==> jaraco.collections)
+        "testtools==2.3.0",  # this has a cycle (fixtures ==> testtols)
+    ],
+)


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Fixes #58 

#### Where should the reviewer start?
Added specific support for setup.py in pip_resolve.py. 
The parsing logic is in setup_file.py

Here's what happens in the code:
It is simple enough. Dependencies in setup.py files are requirements.txt format compliant. Simply read these and act as if it is a requirements.txt file. Also read the `name` and `version` attributes from the setup.py.
