### PR TITLE
feat: optional provenance information for top-level dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ npm-debug.log
 .venvs/
 dist/
 package-lock.json
+
+.nyc_output

--- a/pysrc/pytoml/README.txt
+++ b/pysrc/pytoml/README.txt
@@ -4,3 +4,6 @@ See: https://github.com/avakar/pytoml/releases/tag/v0.1.16
 
 It is bundled out of necessity due to constraints of the
 Snyk CLI plugin architecture.
+
+Also, it contains a Snyk-specific patch: the user-configurable "translate"
+function now also takes a fourth argument, "pos".

--- a/pysrc/pytoml/parser.py
+++ b/pysrc/pytoml/parser.py
@@ -6,10 +6,10 @@ if sys.version_info[0] == 2:
 else:
     _chr = chr
 
-def load(fin, translate=lambda t, x, v: v, object_pairs_hook=dict):
+def load(fin, translate=lambda t, x, v, pos: v, object_pairs_hook=dict):
     return loads(fin.read(), translate=translate, object_pairs_hook=object_pairs_hook, filename=getattr(fin, 'name', repr(fin)))
 
-def loads(s, filename='<string>', translate=lambda t, x, v: v, object_pairs_hook=dict):
+def loads(s, filename='<string>', translate=lambda t, x, v, pos: v, object_pairs_hook=dict):
     if isinstance(s, bytes):
         s = s.decode('utf-8')
 
@@ -35,7 +35,7 @@ def loads(s, filename='<string>', translate=lambda t, x, v: v, object_pairs_hook
             value = [process_value(item, object_pairs_hook=object_pairs_hook) for item in value]
         elif kind == 'table':
             value = object_pairs_hook([(k, process_value(value[k], object_pairs_hook=object_pairs_hook)) for k in value])
-        return translate(kind, text, value)
+        return translate(kind, text, value, pos)
 
     for kind, value, pos in ast:
         if kind == 'kv':

--- a/pysrc/requirements/parser.py
+++ b/pysrc/requirements/parser.py
@@ -2,34 +2,50 @@
 
 import os
 import warnings
+import re
 
 from .requirement import Requirement
 
-
-def parse(reqstr):
+def parse(req_str_or_file):
     """
     Parse a requirements file into a list of Requirements
 
-    See: pip/req.py:parse_requirements()
+    See: pip/req.py:parse_requirements() and
+    https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
 
-    :param reqstr: a string or file like object containing requirements
+    :param req_str_or_file: a string or file like object containing requirements
     :returns: a *generator* of Requirement objects
     """
-    filename = getattr(reqstr, 'name', None)
+    filename = getattr(req_str_or_file, 'name', None)
+    reqstr = req_str_or_file
     try:
         # Python 2.x compatibility
-        if not isinstance(reqstr, basestring):
-            reqstr = reqstr.read()
+        if not isinstance(req_str_or_file, basestring):
+            reqstr = req_str_or_file.read()
     except NameError:
         # Python 3.x only
-        if not isinstance(reqstr, str):
-            reqstr = reqstr.read()
+        if not isinstance(req_str_or_file, str):
+            reqstr = req_str_or_file.read()
 
-    # combine consecutive lines seperated by a backslash
-    reqstr = reqstr.replace('\\\n', ' ')
+    # To deal with lines broken via a backslash
+    initial_zero_based_line_idx = 0
+    accumulator_line_parts = []
 
-    for line in reqstr.splitlines():
+    for zero_based_line_idx, original_line in enumerate(reqstr.splitlines()):
+
+        if original_line.endswith('\\'):
+            accumulator_line_parts.append(original_line.rstrip('\\'))
+            continue
+
+        # Construct a full line from pieces broken by backslashes
+        accumulator_line_parts.append(original_line)
+        original_line_idxs = (initial_zero_based_line_idx, zero_based_line_idx)
+        initial_zero_based_line_idx = zero_based_line_idx + 1
+        line = ' '.join(accumulator_line_parts)
+        accumulator_line_parts = []
+
         line = line.strip()
+
         if line == '':
             continue
         elif not line or line.startswith('#'):
@@ -59,4 +75,10 @@ def parse(reqstr):
                 line.split()[0])
             continue
         else:
-            yield Requirement.parse(line)
+            req = Requirement.parse(line)
+            req.provenance = (
+                filename,
+                original_line_idxs[0] + 1,
+                original_line_idxs[1] + 1,
+            )
+            yield req

--- a/test/workspaces/pip-app/requirements.txt
+++ b/test/workspaces/pip-app/requirements.txt
@@ -3,5 +3,6 @@ Django==1.6.1
 python-etcd==0.4.5
 Django-Select2==6.0.1 # this version installs with lowercase so it catches a previous bug in pip_resolve.py
 irc==16.2 # this has a cyclic dependecy (interanl jaraco.text <==> jaraco.collections)
-testtools==2.3.0 # this has a cycle (fixtures ==> testtols)
+testtools==\
+    2.3.0 # this has a cycle (fixtures ==> testtols);
 ./packages/prometheus_client-0.6.0


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Introduces an undocumented flag `--add-provenance`, which adds the provenance information to the top-level dependencies found by the Python plugin.
