### PR TITLE
feat: apply upgrade remediation to manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ npm-debug.log
 *.egg-info/
 .venvs/
 dist/
+build-with-tests/
 package-lock.json
 
 .nyc_output

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,8 +21,8 @@ type Options = api.SingleSubprojectInspectOptions & PythonInspectOptions;
 export async function inspect(
   root: string,
   targetFile: string,
-  options: Options
-) {
+  options?: Options
+): Promise<api.SinglePackageResult> {
   if (!options) {
     options = {};
   }
@@ -55,6 +55,172 @@ export async function inspect(
     ),
   ]);
   return { plugin, package: pkg };
+}
+
+interface UpgradeRemediation {
+  upgradeTo: string;
+  // Other fields are of no interest
+}
+
+interface DependencyUpdates {
+  [from: string]: UpgradeRemediation;
+}
+
+interface ManifestFiles {
+  // Typically these are requirements.txt, constraints.txt and Pipfile;
+  // the plugin supports paths with subdirectories
+  [name: string]: string; // name-to-content
+}
+
+// Correction for the type; should be fixed in snyk-cli-interface
+export interface DepTreeDep {
+  name?: string; // shouldn't, but might be missing
+  version?: string; // shouldn't, but might be missing
+  dependencies?: {
+    [depName: string]: DepTreeDep;
+  };
+  labels?: {
+    [key: string]: string;
+
+    // Known keys:
+    // pruned: identical subtree already presents in the parent node.
+    //         See --prune-repeated-subdependencies flag.
+  };
+}
+
+// Applies upgrades to direct and indirect dependencies
+export async function applyRemediationToManifests(
+  root: string,
+  manifests: ManifestFiles,
+  upgrades: DependencyUpdates,
+  options: Options
+) {
+  const manifestNames = Object.keys(manifests);
+  const targetFile = manifestNames.find(
+    (fn) => path.basename(fn) === 'requirements.txt'
+  );
+  if (
+    !targetFile ||
+    !manifestNames.every(
+      (fn) =>
+        path.basename(fn) === 'requirements.txt' ||
+        path.basename(fn) === 'constraints.txt'
+    )
+  ) {
+    throw new Error(
+      'Remediation only supported for requirements.txt and constraints.txt files'
+    );
+  }
+
+  const provOptions = { ...options };
+  provOptions.args = provOptions.args || [];
+  provOptions.args.push('--only-provenance');
+
+  const topLevelDeps = (await inspect(root, targetFile, provOptions)).package;
+  applyUpgrades(manifests, upgrades, topLevelDeps);
+
+  return manifests;
+}
+
+function applyUpgrades(
+  manifests: ManifestFiles,
+  upgrades: DependencyUpdates,
+  topLevelDeps: DepTree
+) {
+  const requirementsFileName = Object.keys(manifests).find(
+    (fn) => path.basename(fn) === 'requirements.txt'
+  ) as string;
+  const constraintsFileName = Object.keys(manifests).find(
+    (fn) => path.basename(fn) === 'constraints.txt'
+  );
+
+  // Updates to requirements.txt
+  const patch: { [zeroBasedIndex: number]: string | false } = {}; // false means remove the line
+  const append: string[] = [];
+
+  const originalRequirementsLines = manifests[requirementsFileName].split('\n');
+
+  const extraMarkers = /--| \[|;/;
+
+  for (const upgradeFrom of Object.keys(upgrades)) {
+    const pkgName = upgradeFrom.split('@')[0].toLowerCase();
+    const newVersion = upgrades[upgradeFrom].upgradeTo.split('@')[1];
+    const topLevelDep = (topLevelDeps.dependencies || {})[
+      pkgName
+    ] as DepTreeDep;
+    if (topLevelDep && topLevelDep.labels && topLevelDep.labels.provenance) {
+      // Top level dependency, to be updated in a manifest
+
+      const lineNumbers = topLevelDep.labels.provenance
+        .split(':')[1]
+        .split('-')
+        .map((x) => parseInt(x));
+      // TODO(kyegupov): what if the original version spec was range, e.g. >=1.0,<2.0 ?
+      // TODO(kyegupov): prevent downgrades
+      const firstLineNo = lineNumbers[0] - 1;
+      const lastLineNo =
+        lineNumbers.length > 1 ? lineNumbers[1] - 1 : lineNumbers[0] - 1;
+      const originalRequirementString = originalRequirementsLines
+        .slice(firstLineNo, lastLineNo + 1)
+        .join('\n')
+        .replace(/\\\n/g, '');
+      const firstExtraMarkerPos = originalRequirementString.search(
+        extraMarkers
+      );
+      if (firstExtraMarkerPos > -1) {
+        // maybe we should reinstate linebreaks here?
+        patch[lineNumbers[0] - 1] =
+          pkgName +
+          '==' +
+          newVersion +
+          ' ' +
+          originalRequirementString.slice(firstExtraMarkerPos).trim();
+      } else {
+        patch[lineNumbers[0] - 1] = pkgName + '==' + newVersion;
+      }
+      if (lastLineNo > firstLineNo) {
+        for (let i = firstLineNo + 1; i <= lastLineNo; i++) {
+          patch[i - 1] = false;
+        }
+      }
+    } else {
+      // The dependency is not a top level: we are pinning a transitive using constraints file.
+      if (!constraintsFileName) {
+        append.push(
+          pkgName +
+            '>=' +
+            newVersion +
+            ' # not directly required, pinned by Snyk to avoid a vulnerability'
+        );
+      } else {
+        // TODO(kyegupov): parse constraints and replace the pre-existing one if any
+        const lines = manifests[constraintsFileName].trim().split('\n');
+        lines.push(
+          pkgName +
+            '>=' +
+            newVersion +
+            ' # pinned by Snyk to avoid a vulnerability'
+        );
+        manifests[constraintsFileName] = lines.join('\n') + '\n';
+      }
+    }
+  }
+  const lines: string[] = [];
+  originalRequirementsLines.forEach((line, i) => {
+    if (patch[i] === false) {
+      return;
+    }
+    if (patch[i]) {
+      lines.push(patch[i] as string);
+    } else {
+      lines.push(line);
+    }
+  });
+  // Drop extra trailing newlines
+  while (lines.length > 0 && !lines[lines.length - 1]) {
+    lines.pop();
+  }
+  manifests[requirementsFileName] = lines.concat(append).join('\n') + '\n';
 }
 
 function getMetaData(
@@ -153,6 +319,7 @@ async function getDependencies(
 
   dumpAllFilesInTempDir(tempDirObj.name);
   try {
+    // See ../pysrc/README.md
     const output = await subProcess.execute(
       command,
       [
@@ -173,7 +340,7 @@ async function getDependencies(
       if (error.indexOf('Required packages missing') !== -1) {
         let errMsg = error + '\nPlease run `pip install -r ' + targetFile + '`';
         if (path.basename(targetFile) === 'Pipfile') {
-          errMsg = 'Please run `pipenv update`';
+          errMsg = error + '\nPlease run `pipenv update`';
         }
         throw new Error(errMsg);
       }

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
+    "build-tests": "tsc -p tsconfig-test.json",
     "format:check": "prettier --check '{lib,test}/**/*.{js,ts}'",
     "format": "prettier --write '{lib,test}/**/*.{js,ts}'",
     "prepare": "npm run build",
-    "test": "tap --node-arg=-r --node-arg=ts-node/register ./test/*.test.js -R spec --timeout=900",
-    "lint": "npm run format:check && eslint --cache '{lib,test}/**/*.{js,ts}'",
+    "test": "cross-env TS_NODE_PROJECT=tsconfig-test.json tap --node-arg=-r --node-arg=ts-node/register ./test/*.test.{js,ts} -R spec --timeout=900",
+    "lint": "npm run build-tests && npm run format:check && eslint --cache '{lib,test}/**/*.{js,ts}'",
     "semantic-release": "semantic-release"
   },
   "author": "snyk.io",
@@ -23,10 +24,12 @@
     "tmp": "0.0.33"
   },
   "devDependencies": {
+    "@snyk/types-tap": "^1.1.0",
     "@types/node": "^6.14.6",
     "@types/tmp": "^0.1.0",
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
+    "cross-env": "^5.2.0",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^6.0.0",
     "prettier": "^1.18.2",

--- a/pysrc/README.md
+++ b/pysrc/README.md
@@ -5,7 +5,15 @@ This is the Python part of the snyk-python-plugin.
 Given a fully installed Python package with its dependencies (using a virtual environment),
 it analyzes and returns the dependency tree.
 
-The Node.js code (from the `lib` directory) only sets up the environment and launches this
-analyzer.
-
 The entry point is `main` in `pip_resolve.py`.
+
+## Implementation outline
+
+1. take pkg_resources.working_set (a list of all packages available in the current environment)
+2. convert it to a tree
+3. parse the manifest (requirements.txt/Pipfile) to find top-level deps
+4. select the parts of the tree that start from TLDs found in previous step
+5. determine actual installed versions for the packages in the tree
+6. convert that tree in DepTree format
+
+The parts 1 and 5 require access to the Python environment and thus have to be implemented in Python.

--- a/test/_setup.test.ts
+++ b/test/_setup.test.ts
@@ -1,0 +1,18 @@
+import { test } from 'tap';
+import {
+  ensureVirtualenv,
+  chdirWorkspaces,
+  activateVirtualenv,
+  pipInstall,
+} from './test-utils';
+
+test('install requirements in "pip-app" venv (may take a while)', async (t) => {
+  chdirWorkspaces('pip-app');
+  ensureVirtualenv('pip-app');
+  t.teardown(activateVirtualenv('pip-app'));
+  try {
+    pipInstall();
+  } catch (error) {
+    t.bailout(error);
+  }
+});

--- a/test/fixtures/updated-manifests-with-constraints/constraints.txt
+++ b/test/fixtures/updated-manifests-with-constraints/constraints.txt
@@ -1,0 +1,2 @@
+
+transitive>=1.1.1 # pinned by Snyk to avoid a vulnerability

--- a/test/fixtures/updated-manifests-with-constraints/requirements.txt
+++ b/test/fixtures/updated-manifests-with-constraints/requirements.txt
@@ -1,0 +1,8 @@
+Jinja2==2.7.2
+django==2.0.1
+python-etcd==0.4.5
+Django-Select2==6.0.1 # this version installs with lowercase so it catches a previous bug in pip_resolve.py
+irc==16.2 # this has a cyclic dependecy (interanl jaraco.text <==> jaraco.collections)
+testtools==\
+    2.3.0 # this has a cycle (fixtures ==> testtols);
+./packages/prometheus_client-0.6.0

--- a/test/fixtures/updated-manifests-with-python-markers/requirements.txt
+++ b/test/fixtures/updated-manifests-with-python-markers/requirements.txt
@@ -11,7 +11,7 @@ celery==4.3.0
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4
-click==7.0 ; python_version > '1.0'
+click==7.1 ; python_version > '1.0'
 clickclick==1.2.2
 configparser==3.7.4 ; python_version == '2.7'
 connexion[swagger-ui]==2.2.0

--- a/test/fixtures/updated-manifests-without-constraints/requirements.txt
+++ b/test/fixtures/updated-manifests-without-constraints/requirements.txt
@@ -1,0 +1,9 @@
+Jinja2==2.7.2
+django==2.0.1
+python-etcd==0.4.5
+Django-Select2==6.0.1 # this version installs with lowercase so it catches a previous bug in pip_resolve.py
+irc==16.2 # this has a cyclic dependecy (interanl jaraco.text <==> jaraco.collections)
+testtools==\
+    2.3.0 # this has a cycle (fixtures ==> testtols);
+./packages/prometheus_client-0.6.0
+transitive>=1.1.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/test/inspect-provenance.test.ts
+++ b/test/inspect-provenance.test.ts
@@ -1,0 +1,161 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { test } from 'tap';
+import { chdirWorkspaces, activateVirtualenv } from './test-utils';
+
+import pluginImpl = require('../lib');
+
+const pipAppExpectedDependenciesOnlyProvenance = {
+  django: {
+    data: {
+      name: 'django',
+      version: '1.6.1',
+      labels: { provenance: 'requirements.txt:2' },
+    },
+    msg: 'django looks ok',
+  },
+  jinja2: {
+    data: {
+      name: 'jinja2',
+      version: '2.7.2',
+      labels: { provenance: 'requirements.txt:1' },
+    },
+    msg: 'jinja2 looks ok',
+  },
+  'python-etcd': {
+    data: {
+      name: 'python-etcd',
+      version: '0.4.5',
+      labels: { provenance: 'requirements.txt:3' },
+    },
+    msg: 'python-etcd is ok',
+  },
+  'django-select2': {
+    data: {
+      name: 'django-select2',
+      version: '6.0.1',
+      labels: { provenance: 'requirements.txt:4' },
+    },
+    msg: 'django-select2 looks ok',
+  },
+  irc: {
+    data: {
+      name: 'irc',
+      version: '16.2',
+      labels: { provenance: 'requirements.txt:5' },
+    },
+    msg: 'irc ok, even though it has a cyclic dep, yay!',
+  },
+  testtools: {
+    data: {
+      name: 'testtools',
+      version: '2.3.0',
+      labels: { provenance: 'requirements.txt:6' },
+    },
+    msg: "testtools ok, even though it's cyclic, yay!",
+  },
+};
+
+test('inspect --only-provenance', async (t) => {
+  chdirWorkspaces('pip-app');
+  t.teardown(activateVirtualenv('pip-app'));
+  const result = await pluginImpl.inspect('.', 'requirements.txt', {
+    args: ['--only-provenance'],
+  });
+  const plugin = result.plugin;
+  const pkg = result.package;
+
+  t.test('plugin', async (t) => {
+    t.ok(plugin, 'plugin');
+    t.equal(plugin.name, 'snyk-python-plugin', 'name');
+    t.match(plugin.runtime, 'Python', 'runtime');
+    t.notOk(plugin.targetFile, 'no targetfile for requirements.txt');
+  });
+
+  t.test('package', async (t) => {
+    t.ok(pkg, 'package');
+    t.equal(pkg.name, 'pip-app', 'name');
+    t.equal(pkg.version, '0.0.0', 'version');
+  });
+
+  t.test('package dependencies', async (t) => {
+    Object.keys(pipAppExpectedDependenciesOnlyProvenance).forEach((depName) => {
+      t.match(
+        pkg.dependencies![depName],
+        pipAppExpectedDependenciesOnlyProvenance[depName].data as any,
+        pipAppExpectedDependenciesOnlyProvenance[depName].msg as string
+      );
+    });
+  });
+});
+
+const pipfileExpectedDependenciesOnlyProvenance = {
+  jinja2: {
+    data: {
+      name: 'jinja2',
+      version: '2.7.2',
+      labels: { provenance: 'Pipfile:9' },
+    },
+    msg: 'jinja2 looks ok',
+  },
+  'python-etcd': {
+    data: {
+      name: 'python-etcd',
+      version: '0.4.5',
+      labels: { provenance: 'Pipfile:7' },
+    },
+    msg: 'python-etcd is ok',
+  },
+  'django-select2': {
+    data: {
+      name: 'django-select2',
+      version: '6.0.1',
+      labels: { provenance: 'Pipfile:11' },
+    },
+    msg: 'django-select2 looks ok',
+  },
+  testtools: {
+    data: {
+      name: 'testtools',
+      version: '2.3.0',
+      labels: { provenance: 'Pipfile:8' },
+    },
+    msg: "testtools ok, even though it's cyclic, yay!",
+  },
+};
+
+test('inspect --only-provenance for Pipfile', async (t) => {
+  chdirWorkspaces('pipfile-pipapp');
+  t.teardown(activateVirtualenv('pip-app'));
+  const result = await pluginImpl.inspect('.', 'Pipfile', {
+    args: ['--only-provenance'],
+  });
+  const plugin = result.plugin;
+  const pkg = result.package;
+
+  t.test('plugin', async (t) => {
+    t.ok(plugin, 'plugin');
+    t.equal(plugin.name, 'snyk-python-plugin', 'name');
+    t.match(plugin.runtime, 'Python', 'runtime');
+    t.match(plugin.targetFile, 'Pipfile');
+  });
+
+  t.test('package', async (t) => {
+    t.ok(pkg, 'package');
+    t.equal(pkg.name, 'pipfile-pipapp', 'name');
+    t.equal(pkg.version, '0.0.0', 'version');
+  });
+
+  t.notOk(pkg.dependencies!['django'], 'django skipped (editable)');
+
+  t.test('package dependencies', async (t) => {
+    Object.keys(pipfileExpectedDependenciesOnlyProvenance).forEach(
+      (depName) => {
+        t.match(
+          pkg.dependencies![depName],
+          pipfileExpectedDependenciesOnlyProvenance[depName].data as any,
+          pipfileExpectedDependenciesOnlyProvenance[depName].msg as string
+        );
+      }
+    );
+  });
+});

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -1,7 +1,5 @@
 const test = require('tap').test;
 const fs = require('fs');
-const path = require('path');
-const process = require('process');
 const sinon = require('sinon');
 
 const plugin = require('../lib');
@@ -9,29 +7,17 @@ const subProcess = require('../lib/sub-process');
 const testUtils = require('./test-utils');
 const os = require('os');
 
+const chdirWorkspaces = testUtils.chdirWorkspaces;
+
 function normalize(s) {
   return s.replace(/\r/g, '');
 }
-
-test('install requirements in "pip-app" venv (may take a while)', (t) => {
-  chdirWorkspaces('pip-app');
-  testUtils.ensureVirtualenv('pip-app');
-  t.teardown(testUtils.activateVirtualenv('pip-app'));
-  try {
-    testUtils.pipInstall();
-    t.pass('installed pip packages');
-    t.end();
-  } catch (error) {
-    t.bailout(error);
-  }
-});
 
 const pipAppExpectedDependencies = {
   django: {
     data: {
       name: 'django',
       version: '1.6.1',
-      labels: { provenance: 'requirements.txt:2' },
     },
     msg: 'django looks ok',
   },
@@ -39,7 +25,6 @@ const pipAppExpectedDependencies = {
     data: {
       name: 'jinja2',
       version: '2.7.2',
-      labels: { provenance: 'requirements.txt:1' },
       dependencies: {
         markupsafe: {
           name: 'markupsafe',
@@ -53,7 +38,6 @@ const pipAppExpectedDependencies = {
     data: {
       name: 'python-etcd',
       version: '0.4.5',
-      labels: { provenance: 'requirements.txt:3' },
       dependencies: {
         dnspython: {
           name: 'dnspython',
@@ -71,7 +55,6 @@ const pipAppExpectedDependencies = {
     data: {
       name: 'django-select2',
       version: '6.0.1',
-      labels: { provenance: 'requirements.txt:4' },
       dependencies: {
         'django-appconf': {
           name: 'django-appconf',
@@ -84,7 +67,6 @@ const pipAppExpectedDependencies = {
     data: {
       name: 'irc',
       version: '16.2',
-      labels: { provenance: 'requirements.txt:5' },
       dependencies: {
         'more-itertools': {},
         'jaraco.functools': {},
@@ -106,7 +88,6 @@ const pipAppExpectedDependencies = {
     data: {
       name: 'testtools',
       version: '2.3.0',
-      labels: { provenance: 'requirements.txt:6' },
       dependencies: {
         pbr: {},
         extras: {},
@@ -125,7 +106,6 @@ const pipfilePinnedExpectedDependencies = {
     data: {
       name: 'django',
       version: '1.6.1',
-      labels: { provenance: 'Pipfile:11' },
     },
     msg: 'django looks ok',
   },
@@ -133,7 +113,6 @@ const pipfilePinnedExpectedDependencies = {
     data: {
       name: 'jinja2',
       version: '2.7.2',
-      labels: { provenance: 'Pipfile:10' },
       dependencies: {
         markupsafe: {
           name: 'markupsafe',
@@ -147,7 +126,6 @@ const pipfilePinnedExpectedDependencies = {
     data: {
       name: 'python-etcd',
       version: '0.4.5',
-      labels: { provenance: 'Pipfile:7' },
       dependencies: {
         dnspython: {
           name: 'dnspython',
@@ -165,7 +143,6 @@ const pipfilePinnedExpectedDependencies = {
     data: {
       name: 'django-select2',
       version: '6.0.1',
-      labels: { provenance: 'Pipfile:12' },
       dependencies: {
         'django-appconf': {
           name: 'django-appconf',
@@ -178,7 +155,6 @@ const pipfilePinnedExpectedDependencies = {
     data: {
       name: 'irc',
       version: '16.2',
-      labels: { provenance: 'Pipfile:8' },
       dependencies: {
         'more-itertools': {},
         'jaraco.functools': {},
@@ -200,7 +176,6 @@ const pipfilePinnedExpectedDependencies = {
     data: {
       name: 'testtools',
       version: '2.3.0',
-      labels: { provenance: 'Pipfile:9' },
       dependencies: {
         pbr: {},
         extras: {},
@@ -221,9 +196,7 @@ test('inspect', (t) => {
       t.teardown(testUtils.activateVirtualenv('pip-app'));
     })
     .then(() => {
-      return plugin.inspect('.', 'requirements.txt', {
-        args: ['--add-provenance'],
-      });
+      return plugin.inspect('.', 'requirements.txt');
     })
     .then((result) => {
       const plugin = result.plugin;
@@ -745,7 +718,7 @@ test('inspect Pipfile with pinned versions', (t) => {
       t.teardown(testUtils.activateVirtualenv('pip-app'));
     })
     .then(() => {
-      return plugin.inspect('.', 'Pipfile', { args: ['--add-provenance'] });
+      return plugin.inspect('.', 'Pipfile');
     })
     .then((result) => {
       const pkg = result.package;
@@ -771,7 +744,6 @@ const pipenvAppExpectedDependencies = {
     data: {
       name: 'python-etcd',
       version: /^0\.4/,
-      labels: { provenance: 'Pipfile:7' },
     },
     msg: 'python-etcd1 found with version >=0.4,<0.5',
   },
@@ -779,14 +751,12 @@ const pipenvAppExpectedDependencies = {
     data: {
       name: 'jinja2',
       version: /^0|1|2\.[0-6]/,
-      labels: { provenance: 'Pipfile:9' },
     },
     msg: 'jinja2 found with version <2.7',
   },
   testtools: {
     data: {
       name: 'testtools',
-      labels: { provenance: 'Pipfile:8' },
     },
     msg: 'testtools found',
   },
@@ -804,7 +774,7 @@ test('inspect pipenv app with user-created virtualenv', (t) => {
       }
     })
     .then(() => {
-      return plugin.inspect('.', 'Pipfile', { args: ['--add-provenance'] });
+      return plugin.inspect('.', 'Pipfile');
     })
     .then((result) => {
       const pkg = result.package;
@@ -860,7 +830,7 @@ test('inspect pipenv app with auto-created virtualenv', (t) => {
       }
     })
     .then(() => {
-      return plugin.inspect('.', 'Pipfile', { args: ['--add-provenance'] });
+      return plugin.inspect('.', 'Pipfile');
     })
     .then((result) => {
       const pkg = result.package;
@@ -895,7 +865,6 @@ test('inspect pipenv app dev dependencies', (t) => {
     .then(() => {
       return plugin.inspect('.', 'Pipfile', {
         dev: true,
-        args: ['--add-provenance'],
       });
     })
     .then((result) => {
@@ -941,7 +910,3 @@ test('package names with urls are skipped', (t) => {
       );
     });
 });
-
-function chdirWorkspaces(dir) {
-  process.chdir(path.resolve(__dirname, 'workspaces', dir));
-}

--- a/test/remediation.test.ts
+++ b/test/remediation.test.ts
@@ -1,0 +1,140 @@
+import { test } from 'tap';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import plugin = require('../lib');
+import { chdirWorkspaces } from './test-utils';
+const testUtils = require('./test-utils') as any;
+
+function readDirAsFiles(dir: string) {
+  const res = {};
+  fs.readdirSync(dir).forEach((fn) => {
+    res[fn] = fs.readFileSync(path.join(dir, fn), 'utf8');
+  });
+  return res;
+}
+
+test('remediation with constraints.txt', async (t) => {
+  chdirWorkspaces('pip-app');
+  t.teardown(testUtils.activateVirtualenv('pip-app'));
+  const upgrades = {
+    'DJANGO@1.6.1': { upgradeTo: 'Django@2.0.1' }, // Note different capitalisation
+    'transitive@1.0.0': { upgradeTo: 'transitive@1.1.1' },
+  };
+
+  const manifests = {
+    'requirements.txt': fs.readFileSync('requirements.txt', 'utf8'),
+    'constraints.txt': '',
+  };
+
+  const expectedUpdatedManifests = readDirAsFiles(
+    '../../fixtures/updated-manifests-with-constraints'
+  );
+
+  const result = await plugin.applyRemediationToManifests(
+    '.',
+    manifests,
+    upgrades,
+    {}
+  );
+
+  t.same(result, expectedUpdatedManifests, 'remediation as expected');
+});
+
+test('remediation without constraints.txt', async (t) => {
+  chdirWorkspaces('pip-app');
+  t.teardown(testUtils.activateVirtualenv('pip-app'));
+  const upgrades = {
+    'Django@1.6.1': { upgradeTo: 'Django@2.0.1' },
+    'transitive@1.0.0': { upgradeTo: 'transitive@1.1.1' },
+  };
+
+  const manifests = {
+    'requirements.txt': fs.readFileSync('requirements.txt', 'utf8'),
+  };
+
+  const expectedUpdatedManifests = readDirAsFiles(
+    '../../fixtures/updated-manifests-without-constraints'
+  );
+
+  const result = await plugin.applyRemediationToManifests(
+    '.',
+    manifests,
+    upgrades,
+    {}
+  );
+
+  t.same(result, expectedUpdatedManifests, 'remediation as expected');
+});
+
+// TODO(kyegupov): tests for other additional attributes
+test('remediation - retains python markers', async (t) => {
+  chdirWorkspaces('pip-app-with-python-markers');
+  const venvCreated = testUtils.ensureVirtualenv('pip-app-with-python-markers');
+  t.teardown(testUtils.activateVirtualenv('pip-app-with-python-markers'));
+  if (venvCreated) {
+    testUtils.pipInstall();
+  }
+  const upgrades = {
+    'click@7.0': { upgradeTo: 'click@7.1' },
+  };
+
+  const manifests = {
+    'requirements.txt': fs.readFileSync('requirements.txt', 'utf8'),
+  };
+
+  const expectedUpdatedManifests = readDirAsFiles(
+    '../../fixtures/updated-manifests-with-python-markers'
+  );
+
+  const result = await plugin.applyRemediationToManifests(
+    '.',
+    manifests,
+    upgrades,
+    {}
+  );
+
+  t.same(result, expectedUpdatedManifests, 'remediation as expected');
+});
+
+test('remediation without constraints.txt - no-op upgrades', async (t) => {
+  chdirWorkspaces('pip-app');
+  t.teardown(testUtils.activateVirtualenv('pip-app'));
+  const upgrades = {};
+
+  const manifests = {
+    'requirements.txt': fs.readFileSync('requirements.txt', 'utf8'),
+  };
+
+  const result = await plugin.applyRemediationToManifests(
+    '.',
+    manifests,
+    upgrades,
+    {}
+  );
+
+  t.same(result, manifests, 'remediation as expected (unchanged)');
+});
+
+test('remediation for Pipfile', async (t) => {
+  chdirWorkspaces('pipfile-pipapp');
+  t.teardown(testUtils.activateVirtualenv('pipfile-pipapp'));
+  const upgrades = {
+    'Django@1.6.1': { upgradeTo: 'Django@2.0.1' },
+    'transitive@1.0.0': { upgradeTo: 'transitive@1.1.1' },
+  };
+
+  const manifests = {
+    Pipfile: fs.readFileSync('Pipfile', 'utf8'),
+  };
+
+  try {
+    await plugin.applyRemediationToManifests('.', manifests, upgrades, {});
+    t.fail('expected exception');
+  } catch (e) {
+    t.match(
+      e.message,
+      'Remediation only supported for requirements.txt and constraints.txt files'
+    );
+  }
+});

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,11 +1,11 @@
-/* eslint-disable no-console */
-const fs = require('fs');
-const path = require('path');
-const process = require('process');
+/* eslint-disable no-console, @typescript-eslint/no-non-null-assertion */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as process from 'process';
 
-const subProcess = require('../lib/sub-process');
+import subProcess = require('../lib/sub-process');
 
-module.exports = {
+export {
   getActiveVenvName,
   activateVirtualenv,
   deactivateVirtualenv,
@@ -32,7 +32,7 @@ function activateVirtualenv(venvName) {
   const origProcessEnv = Object.assign({}, process.env);
 
   if (process.env.VIRTUAL_ENV) {
-    const pathElements = process.env.PATH.split(path.delimiter);
+    const pathElements = process.env.PATH!.split(path.delimiter);
     const index = pathElements.indexOf(process.env.VIRTUAL_ENV);
     if (index > -1) {
       pathElements.splice(index, 1);
@@ -55,14 +55,14 @@ function activateVirtualenv(venvName) {
 function deactivateVirtualenv() {
   if (getActiveVenvName() === null) {
     console.warn('Attempted to deactivate a virtualenv when none was active.');
-    return;
+    return () => {};
   }
 
   const origProcessEnv = Object.assign({}, process.env);
 
   // simulate the "deactivate" virtualenv script
-  const pathElements = process.env.PATH.split(path.delimiter);
-  const venvBinDir = path.join(process.env.VIRTUAL_ENV, binDirName);
+  const pathElements = process.env.PATH!.split(path.delimiter);
+  const venvBinDir = path.join(process.env.VIRTUAL_ENV!, binDirName);
   const index = pathElements.indexOf(venvBinDir);
   if (index > -1) {
     pathElements.splice(index, 1);
@@ -81,14 +81,14 @@ function deactivateVirtualenv() {
 function ensureVirtualenv(venvName) {
   const venvsBaseDir = path.join(path.resolve(__dirname), '.venvs');
   try {
-    fs.accessSync(venvsBaseDir, fs.R_OK);
+    fs.accessSync(venvsBaseDir, fs.constants.R_OK);
   } catch (e) {
     fs.mkdirSync(venvsBaseDir);
   }
 
   const venvDir = path.join(venvsBaseDir, venvName);
   try {
-    fs.accessSync(venvDir, fs.R_OK);
+    fs.accessSync(venvDir, fs.constants.R_OK);
     return false;
   } catch (e) {
     createVenv(venvDir);
@@ -97,7 +97,7 @@ function ensureVirtualenv(venvName) {
 }
 
 function createVenv(venvDir) {
-  let revert = function() {};
+  let revert = () => {};
   if (process.env.VIRTUAL_ENV) {
     revert = deactivateVirtualenv();
   }
@@ -169,7 +169,7 @@ function pipenvInstall() {
 function setWorkonHome() {
   const venvsBaseDir = path.join(path.resolve(__dirname), '.venvs');
   try {
-    fs.accessSync(venvsBaseDir, fs.R_OK);
+    fs.accessSync(venvsBaseDir, fs.constants.R_OK);
   } catch (e) {
     fs.mkdirSync(venvsBaseDir);
   }
@@ -180,4 +180,8 @@ function setWorkonHome() {
   return function revert() {
     process.env.WORKON_HOME = origWorkonHome;
   };
+}
+
+export function chdirWorkspaces(dir) {
+  process.chdir(path.resolve(__dirname, 'workspaces', dir));
 }

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./build-with-tests",
+    "declaration": false,
+    "noImplicitAny": false,
+  },
+  "include": [
+    "./lib/**/*", "./test/**/*"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,9 @@
       "sourceMap": true,
       "strict": true,
       "declaration": true,
-      "importHelpers": true
+      "importHelpers": true,
   },
   "include": [
-      "./lib/**/*"
+    "./lib/**/*"
   ]
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Adds exported function that applies updates to the manifest files.
This has to happen in the plugin, because that's where the manifests are parsed.
Currently would only used by Registry (via pip-deps, which creates the Python environment) to prepare fix PRs.

#### Where should the reviewer start?
applyRemediationToManifests is the main entry point
