### PR TITLE
chore: enable early bailout for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,5 @@ jobs:
 branches:
   only:
     - master
+matrix:
+  fast_finish: true


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
I think that's the flag that allows Travis not to finish the entire matrix of builds if one of them fails, so the build queue will be freed up.
