### PR TITLE
chore: Prevent lockfile generation

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
We don't use lockfiles for our libraries, as `npm install` doesn't consume anything other than the top-level lockfile anyway; this means the tests continuously run on new versions, which means we catch issues before they affect customers (hopefully).

The lockfile is current in the `.gitignore`, but may still be generated locally, so this patch adds a `.npmrc` flag to prevent this.