### PR TITLE
fix: update ancient test dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@snyk/cli-interface": "^2.0.2",
-    "tmp": "0.0.33"
+    "tmp": "^0.1.0"
   },
   "devDependencies": {
     "@snyk/types-tap": "^1.1.0",
@@ -30,11 +30,11 @@
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
     "cross-env": "^5.2.0",
-    "eslint": "^5.16.0",
+    "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",
     "prettier": "^1.18.2",
-    "sinon": "^2.3.2",
-    "tap": "^12.6.1",
+    "sinon": "^7.4.1",
+    "tap": "^14.6.1",
     "ts-node": "^8.1.0",
     "typescript": "^3.4.5"
   }


### PR DESCRIPTION
Generally there should be a consumable reason for updating dependencies i.e. new features, but these are so old (sinon was _5_ major versions out) that I think its worth a group update