### PR TITLE
fix: match python_version with wildcards (e.g. "2.*")

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "format:check": "prettier --check '{lib,test}/**/*.{js,ts}'",
     "format": "prettier --write '{lib,test}/**/*.{js,ts}'",
     "prepare": "npm run build",
-    "test": "cross-env TS_NODE_PROJECT=tsconfig-test.json tap --node-arg=-r --node-arg=ts-node/register ./test/*.test.{js,ts} -R spec --timeout=900",
+    "test": "npm run test:pysrc && npm run test:js",
+    "test:js": "cross-env TS_NODE_PROJECT=tsconfig-test.json tap --node-arg=-r --node-arg=ts-node/register ./test/*.test.{js,ts} -R spec --timeout=900",
+    "test:pysrc": "python -m unittest discover pysrc",
     "lint": "npm run build-tests && npm run format:check && eslint --cache '{lib,test}/**/*.{js,ts}'",
     "semantic-release": "semantic-release"
   },

--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -123,7 +123,7 @@ def create_tree_of_packages_dependencies(
             dir_as_root[DEPENDENCIES][package_as_root[NAME]] = package_tree
     return dir_as_root
 
-def satisfies_python_requirement(parsed_operator, parsed_python_version):
+def satisfies_python_requirement(parsed_operator, py_version_str, sys=sys):
     # TODO: use python semver library to compare versions
     operator_func = {
         ">": gt,
@@ -133,8 +133,15 @@ def satisfies_python_requirement(parsed_operator, parsed_python_version):
         ">=": ge,
         '!=': ne,
     }[parsed_operator]
-    system_python = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
-    return operator_func(float(system_python), float(parsed_python_version))
+    system_py_version_tuple = (sys.version_info[0], sys.version_info[1])
+    py_version_tuple = tuple(py_version_str.split('.')) # string tuple
+    if py_version_tuple[-1] == '*':
+        system_py_version_tuple = system_py_version_tuple[0]
+        py_version_tuple = int(py_version_tuple[0]) # int tuple
+    else:
+        py_version_tuple = tuple(int(x) for x in py_version_tuple) # int tuple
+
+    return operator_func(system_py_version_tuple, py_version_tuple)
 
 def get_markers_text(requirement):
     if isinstance(requirement, pipfile.PipfileRequirement):

--- a/pysrc/test_pip_resolve.py
+++ b/pysrc/test_pip_resolve.py
@@ -1,0 +1,24 @@
+# run with:
+# cd pysrc; python3 pip_resolve_test.py; cd ..
+
+from pip_resolve import satisfies_python_requirement
+from collections import namedtuple
+
+import unittest
+
+fake_sys = namedtuple('Sys', ['version_info'])
+
+class TestStringMethods(unittest.TestCase):
+
+    def test(self):
+        self.assertTrue(satisfies_python_requirement('>', '2.4', sys=fake_sys((2, 5))))
+        self.assertTrue(satisfies_python_requirement('==', '2.3', sys=fake_sys((2, 3))))
+        self.assertTrue(satisfies_python_requirement('<=', '2.3', sys=fake_sys((2, 3))))
+        self.assertFalse(satisfies_python_requirement('<', '2.3', sys=fake_sys((2, 3))))
+        self.assertTrue(satisfies_python_requirement('>', '3.1', sys=fake_sys((3, 5))))
+        self.assertFalse(satisfies_python_requirement('>', '3.1', sys=fake_sys((2, 8))))
+        self.assertTrue(satisfies_python_requirement('==', '2.*', sys=fake_sys((2, 6))))
+        self.assertTrue(satisfies_python_requirement('==', '3.*', sys=fake_sys((3, 6))))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
fixes an issue where lines like `enum34==1.1.6 ; python_version == '2.*'` were not supported
