### PR TITLE
Adding python package name canonicalization.

### DIFF
--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -231,6 +231,14 @@ def get_requirements_list(requirements_file_path, dev_deps=False):
         req.name = req.name.lower().replace('_', '-')
     return req_list
 
+
+def canonicalize_package_name(name):
+    # https://packaging.python.org/guides/distributing-packages-using-setuptools/#name
+    name = name.lower().replace('-', '.').replace('_', '.')
+    name = re.sub(r'\.+', '.', name)
+    return name
+
+
 def create_dependencies_tree_by_req_file_path(requirements_file_path,
                                               allow_missing=False,
                                               dev_deps=False,
@@ -246,11 +254,11 @@ def create_dependencies_tree_by_req_file_path(requirements_file_path,
 
     # create a list of dependencies from the dependencies file
     required = get_requirements_list(requirements_file_path, dev_deps=dev_deps)
-    installed = [p for p in dist_index]
+    installed = [canonicalize_package_name(p) for p in dist_index]
     top_level_requirements = []
     missing_package_names = []
     for r in required:
-        if r.name not in installed:
+        if canonicalize_package_name(r.name) not in installed:
             missing_package_names.append(r.name)
         else:
             top_level_requirements.append(r)

--- a/pysrc/test_pip_resolve.py
+++ b/pysrc/test_pip_resolve.py
@@ -3,7 +3,8 @@
 
 from pip_resolve import satisfies_python_requirement, \
                         matches_python_version, \
-                        matches_environment
+                        matches_environment, \
+                        canonicalize_package_name
 from collections import namedtuple
 
 import unittest
@@ -14,6 +15,17 @@ except:
     from unittest.mock import patch
 
 class TestStringMethods(unittest.TestCase):
+
+    def test_canonicalize_package_name(self):
+        # https://packaging.python.org/guides/distributing-packages-using-setuptools/#name
+        self.assertEqual(canonicalize_package_name("Cool-Stuff"), "cool.stuff")
+        self.assertEqual(canonicalize_package_name("Cool--.--Stuff"), "cool.stuff")
+        self.assertEqual(canonicalize_package_name("Cool--__.__--Stuff"), "cool.stuff")
+
+        self.assertEqual(canonicalize_package_name("cool.stuff"), "cool.stuff")
+        self.assertEqual(canonicalize_package_name("COOL_STUFF"), "cool.stuff")
+        self.assertEqual(canonicalize_package_name("CoOl__-.-__sTuFF"), "cool.stuff")
+
 
     def test_satisfies_python_requirement(self):
 


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
I took a stab at fixing #85.
I also added unit tests.

Someone with more knowledge of how snyk handles dependency graphs for python should take a look. I only solved my immediate problem, but the new `canonicalize_package_name(name)` method could (and should) probably be used in other places.

#### Where should the reviewer start?
1) Look at #85.
2) Read https://packaging.python.org/guides/distributing-packages-using-setuptools/#name
3) Look at the unit tests I added.

#### How should this be manually tested?
Setup a Pipfile that references a package with a hyphon in the name, but where the package displays a period when you do a pip freeze.

(I would provide an example, but I ran into this problem on internal projects.)

#### Any background context you want to provide?
Found this problem while evaluating Snyk. I have a meeting with 
`elisabeth@snyk.io` tomorrow morning. Helping get these (and other) issues fixed quickly will totally help your sales people :).

#### What are the relevant tickets?
Should address Issue 85
https://github.com/snyk/snyk-python-plugin/issues/85

#### Screenshots
Nope

#### Additional questions
