### PR TITLE
feat: support setup.py as a return target file

### DIFF
--- a/lib/inspect-implementation.ts
+++ b/lib/inspect-implementation.ts
@@ -17,9 +17,10 @@ export function getMetaData(
       return {
         name: 'snyk-python-plugin',
         runtime: output.replace('\n', ''),
-        // specify targetFile only in case of Pipfile
-        targetFile:
-          path.basename(targetFile) === 'Pipfile' ? targetFile : undefined,
+        // specify targetFile only in case of Pipfile or setup.py
+        targetFile: path.basename(targetFile).match(/^(Pipfile|setup\.py)$/)
+          ? targetFile
+          : undefined,
       };
     });
 }

--- a/test/inspect-provenance.test.ts
+++ b/test/inspect-provenance.test.ts
@@ -224,7 +224,7 @@ test('inspect setup.py', async (t) => {
     t.ok(plugin, 'plugin');
     t.equal(plugin.name, 'snyk-python-plugin', 'name');
     t.match(plugin.runtime, 'Python', 'runtime');
-    t.notOk(plugin.targetFile, 'no targetfile for setup.py');
+    t.equal(plugin.targetFile, 'setup.py', 'targetfile is setup.py');
   });
 
   t.test('package', async (t) => {

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -338,7 +338,7 @@ test('inspect setup.py', (t) => {
         t.ok(plugin, 'plugin');
         t.equal(plugin.name, 'snyk-python-plugin', 'name');
         t.match(plugin.runtime, 'Python', 'runtime');
-        t.notOk(plugin.targetFile, 'no targetfile for setup.py');
+        t.equal(plugin.targetFile, 'setup.py', 'targetfile is setup.py');
         t.end();
       });
 


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?
Add return `targetFile` from plugin `setup.py` if it's the project manifest