### PR TITLE
fix: Correct the release process in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,6 +276,8 @@ jobs:
           command: npm run build
   release:
     <<: *defaults
+    docker:
+      - image: node:8
     steps:
       - checkout_and_merge
       - run:


### PR DESCRIPTION
Node 6 doesn't include a version of npm that bundles npx, so we build with 8. Everything is still tested (including the build) under node 6 from the test flow, so it should be okay.