### PR TITLE
fix: Match multiple digits in package versions

### DIFF
--- a/lib/requirements-file-parser.ts
+++ b/lib/requirements-file-parser.ts
@@ -35,7 +35,7 @@ export function parseRequirementsFile(requirementsFile: string): Requirement[] {
 
     // Regex to match against a Python package specifier. Any invalid lines (or
     // lines we can't handle) should have been returned this point.
-    const regex = /([A-Z0-9]*)(===|==|>=|<=|>|<|~=)(\d\.?\d?\.?\d?)(.*)/i;
+    const regex = /([A-Z0-9]*)(!=|==|>=|<=|>|<|~=)(\d*\.?\d*\.?\d*)(.*)/i;
     const result = regex.exec(requirementText);
 
     if (result !== null) {

--- a/test/remediation.spec.ts
+++ b/test/remediation.spec.ts
@@ -60,6 +60,24 @@ describe('remediation', () => {
     expect(result).toEqual(expectedManifests);
   });
 
+  it('matches a package with multiple digit versions i.e. 12.123.14', () => {
+    const upgrades = {
+      'foo@12.123.14': { upgradeTo: 'foo@55.66.7' },
+    };
+
+    const manifests = {
+      'requirements.txt': 'foo==12.123.14\n',
+    };
+
+    const expectedManifests = {
+      'requirements.txt': 'foo==55.66.7\n',
+    };
+
+    const result = applyRemediationToManifests(manifests, upgrades);
+
+    expect(result).toEqual(expectedManifests);
+  });
+
   it('maintains comments when upgrading', () => {
     const upgrades = {
       'django@1.6.1': { upgradeTo: 'django@2.0.1' },


### PR DESCRIPTION
The new requirements parser and tests were only matching single digits in version strings, such as `2.0.1`, which falls over very quickly, for example when faced with `flask==0.12.1`.

This patch fixes the parser, and adds a test