### PR TITLE
fix: use file contents to update deps not a file object (support for custom named manifests)

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,4 +3,4 @@ export {
   PythonInspectOptions,
 } from './dependencies';
 
-export { updateDependencies as applyRemediationToManifests } from './update-dependencies';
+export { updateDependencies } from './update-dependencies';

--- a/lib/requirements-file-parser.ts
+++ b/lib/requirements-file-parser.ts
@@ -1,6 +1,6 @@
 type VersionComparator = '<' | '<=' | '!=' | '==' | '>=' | '>' | '~=';
 
-interface Requirement {
+export interface Requirement {
   originalText: string;
   line: number;
   name?: string;


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Based on: https://github.com/snyk/snyk-python-plugin/pull/98/files
#### Where should the reviewer start?
https://github.com/snyk/snyk-python-plugin/pull/99/commits/984c6a6289376a9dfa5892f247c3ef62237186e5

New file types will require very different handling anyway
So will fixing multiple files together at that stage this should be refactored or a separate new function will be created.
