### PR TITLE
now is possible to assign python version with --python= property.

### DIFF
--- a/lib/dependencies/index.ts
+++ b/lib/dependencies/index.ts
@@ -6,6 +6,7 @@ import { getMetaData, inspectInstalledDeps } from './inspect-implementation';
 
 export interface PythonInspectOptions {
   command?: string; // `python` command override
+  python?: string;
   allowMissing?: boolean; // Allow skipping packages that are not found in the environment.
   args?: string[];
 }
@@ -22,7 +23,16 @@ export async function getDependencies(
   if (!options) {
     options = {};
   }
-  let command = options.command || 'python';
+
+  if (options.python && options.python !== '2' && options.python !== '3') {
+    throw new Error(
+      'The --python property can be used only as --python=2 or --python=3'
+    );
+  }
+
+  const python = options.python ? `python${options.python}` : 'python';
+
+  let command = options.command || python;
   const includeDevDeps = !!(options.dev || false);
   let baseargs: string[] = [];
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
This PR adds new property to set a python version while using snyk-cli.
To work is required to use **snyk-cli** updated version with new property and using this snyk-python-plugin update.
This new command is handling properly the error message upon e.g. --python=maven which is a wrong way of execute it.

#### Any background context you want to provide?
On this pr the old command='python2' still works perfectly, the goal was only
to introduce a new command that repeats its behaviour.

Working case
#### Screenshots
<img width="637" alt="Screen Shot 2020-02-27 at 15 27 24" src="https://user-images.githubusercontent.com/40601533/75449965-a22b9680-5976-11ea-929c-7f88461a5b22.png">

Throw Error on bad usage
<img width="631" alt="Screen Shot 2020-02-27 at 15 37 30" src="https://user-images.githubusercontent.com/40601533/75450320-41508e00-5977-11ea-94d2-cc444928a907.png">

snyk-cli pr
https://github.com/snyk/snyk/pull/1031
