### PR TITLE
fix: ensure to always throw errors and suggest the cause

### DIFF
--- a/lib/dependencies/inspect-implementation.ts
+++ b/lib/dependencies/inspect-implementation.ts
@@ -133,6 +133,11 @@ export async function inspectInstalledDeps(
         errMsg += ' If the issue persists try again with --skip-unresolved.';
         throw new Error(errMsg);
       }
+
+      // The error most likely comes from python/pip.
+      // Ensure we don't just throw a string as the exception object
+      // otherwise we cannot render anything meaningful with Snyk CLI (we get undefined).
+      throw new Error(error + '\nIs pip installed in your environment?');
     }
     throw error;
   } finally {

--- a/test/error-handling.test.ts
+++ b/test/error-handling.test.ts
@@ -1,0 +1,28 @@
+import { test } from 'tap';
+import * as sinon from 'sinon';
+import { join } from 'path';
+
+import { inspect } from '../lib/index';
+
+// Sinon mocks
+import * as subProcess from '../lib/dependencies/sub-process';
+
+test('returns error from subprocess with suggestion for the cause', async (t) => {
+  const stub = sinon
+    .stub(subProcess, 'execute')
+    .throws(
+      () =>
+        `'Traceback (most recent call last):\n File "/tmp/tmp-38340UzUyyvr3Qqv/pip_resolve.py", line 7, in <module>\n import utils\n File "/tmp/tmp-38340UzUyyvr3Qqv/utils.py", line 8, in <module>\n from reqPackage import ReqPackage\n File "/tmp/tmp-38340UzUyyvr3Qqv/reqPackage.py", line 1, in <module>\n import pkg_resources\nImportError: No module named pkg_resources\n'`
+    );
+
+  t.teardown(stub.restore);
+
+  await t.rejects(
+    () =>
+      inspect(
+        join(__dirname, 'fixtures', 'updated-manifest', 'requirements.txt'),
+        'requirements.txt'
+      ),
+    `'Traceback (most recent call last):\n File "/tmp/tmp-38340UzUyyvr3Qqv/pip_resolve.py", line 7, in <module>\n import utils\n File "/tmp/tmp-38340UzUyyvr3Qqv/utils.py", line 8, in <module>\n from reqPackage import ReqPackage\n File "/tmp/tmp-38340UzUyyvr3Qqv/reqPackage.py", line 1, in <module>\n import pkg_resources\nImportError: No module named pkg_resources\n'\nIs pip installed in your environment?`
+  );
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

The plugin sometimes throws plain strings as the exception object, instead of an Error that wraps this string.
The resulting effect is that the Snyk CLI can work only with Error/exception objects and in such cases will print "undefined" which is a bad user experience.

The reason for a string error comes from the pip/python subprocess that we launch, so this fix also suggests to check if pip is installed in the current environment.

#### What are the relevant tickets?

[Zendesk #5607](https://snyk.zendesk.com/agent/tickets/5607)

#### Additional notes

Tested manually with a local version of the Snyk CLI.
|Before|After|
|--|--|
| <img width="1110" alt="Screenshot 2020-07-07 at 18 08 48" src="https://user-images.githubusercontent.com/16717473/86804102-8cd61f80-c06e-11ea-932e-c085630a998a.png"> | <img width="1104" alt="Screenshot 2020-07-07 at 18 25 44" src="https://user-images.githubusercontent.com/16717473/86804126-93fd2d80-c06e-11ea-962d-1ce59cc74121.png"> |

