### PR TITLE
feat: add poetry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Snyk helps you find, fix and monitor for known vulnerabilities in your dependenc
 This plugin provides dependency metadata for Python projects that use one of the following dependency management methods:
 
 * `pip` with a `requirements.txt` file
-* `pipenv` with a `Pipefile` file
+* `pipenv` with a `Pipfile` file
+* `poetry` with `pyproject.toml` and `poetry.lock`
 
 There's a special `only-provenance` mode that allows extracting of top-level dependencies with
 their corresponding positions in the original manifest file.
@@ -24,7 +25,7 @@ their corresponding positions in the original manifest file.
 ### Developing and Testing
 
 Prerequisites:
-- Node.js 6+
+- Node.js 8+
 - Python 2.7 or 3.6+
 - Installed outside of any virtualenv:
     - [pip](https://pip.pypa.io/en/stable/installing/)
@@ -32,7 +33,8 @@ Prerequisites:
       ```
       pip install --user -r dev-requirements.txt
       ``` 
-
+- if in linux, `python-dev` installed with apt, or see [here](https://stackoverflow.com/a/21530768).
+ 
 Tests can be run against multiple python versions by using tox:
 
 ```

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   coverageDirectory: '<rootDir>/reports/coverage',
   testMatch: ['**/*.spec.ts'], // Remove when all tests are using Jest
   modulePathIgnorePatterns: ['<rootDir>/dist', '<rootDir/reports>'],
+  setupFilesAfterEnv: ['<rootDir>/test/matchers/setup.ts'],
   reporters: [
     'default',
     [

--- a/lib/dependencies/inspect-implementation.ts
+++ b/lib/dependencies/inspect-implementation.ts
@@ -4,6 +4,7 @@ import * as tmp from 'tmp';
 
 import * as subProcess from './sub-process';
 import { legacyCommon } from '@snyk/cli-interface';
+import { FILENAMES } from '../types';
 
 export function getMetaData(
   command: string,
@@ -18,7 +19,9 @@ export function getMetaData(
         name: 'snyk-python-plugin',
         runtime: output.replace('\n', ''),
         // specify targetFile only in case of Pipfile or setup.py
-        targetFile: path.basename(targetFile).match(/^(Pipfile|setup\.py)$/)
+        targetFile: path
+          .basename(targetFile)
+          .match(/^(Pipfile|setup\.py|pyproject\.toml)$/)
           ? targetFile
           : undefined,
       };
@@ -123,9 +126,11 @@ export async function inspectInstalledDeps(
     if (typeof error === 'string') {
       if (error.indexOf('Required packages missing') !== -1) {
         let errMsg = error;
-        if (path.basename(targetFile) === 'Pipfile') {
+        if (path.basename(targetFile) === FILENAMES.pipenv.manifest) {
           errMsg += '\nPlease run `pipenv update`.';
-        } else if (path.basename(targetFile) === 'setup.py') {
+        } else if (
+          path.basename(targetFile) === FILENAMES.setuptools.manifest
+        ) {
           errMsg += '\nPlease run `pip install -e .`.';
         } else {
           errMsg += '\nPlease run `pip install -r ' + targetFile + '`.';

--- a/lib/dependencies/poetry.ts
+++ b/lib/dependencies/poetry.ts
@@ -1,0 +1,45 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { SinglePackageResult } from '@snyk/cli-interface/legacy/plugin';
+import * as poetry from 'snyk-poetry-lockfile-parser';
+import { getMetaData } from './inspect-implementation';
+import { FILENAMES } from '../types';
+
+export async function getPoetryDependencies(
+  command: string,
+  root: string,
+  targetFile: string,
+  includeDevDeps = false
+): Promise<SinglePackageResult> {
+  const manifestPath = path.join(root, targetFile);
+  const baseDir = path.dirname(manifestPath);
+  const lockfilePath = path.join(baseDir, FILENAMES.poetry.lockfile);
+  const manifestExists = fs.existsSync(manifestPath);
+  if (!manifestExists) {
+    throw new Error('Cannot find manifest file ' + manifestPath);
+  }
+  const lockfileExists = fs.existsSync(lockfilePath);
+  if (!lockfileExists) {
+    throw new Error('Cannot find lockfile ' + lockfilePath);
+  }
+
+  try {
+    const manifestContents = fs.readFileSync(manifestPath, 'utf-8');
+    const lockfileContents = fs.readFileSync(lockfilePath, 'utf-8');
+    const dependencyGraph = poetry.buildDepGraph(
+      manifestContents,
+      lockfileContents,
+      includeDevDeps
+    );
+    const plugin = await getMetaData(command, [], root, targetFile);
+    return {
+      plugin,
+      package: null,
+      dependencyGraph,
+    };
+  } catch (error) {
+    throw new Error(
+      'Error processing poetry project. ' + error.message || error
+    );
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,3 +9,24 @@ export interface ManifestFiles {
   // the plugin supports paths with subdirectories
   [name: string]: string; // name-to-content
 }
+
+export type PackageManagers = 'pip' | 'setuptools' | 'pipenv' | 'poetry';
+
+export const FILENAMES: {
+  [key in PackageManagers]: { manifest: string; lockfile?: string };
+} = {
+  pip: {
+    manifest: 'requirementes.txt',
+  },
+  setuptools: {
+    manifest: 'setup.py',
+  },
+  pipenv: {
+    manifest: 'Pipfile',
+    lockfile: 'Pipfile.lock',
+  },
+  poetry: {
+    manifest: 'pyproject.toml',
+    lockfile: 'poetry.lock',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "format:check": "prettier --check '{lib,test}/**/*.{js,ts}'",
     "format": "prettier --write '{lib,test}/**/*.{js,ts}'",
     "prepare": "npm run build",
-    "test": "npm run test:pysrc && npm run test:js",
-    "test:js": "cross-env TS_NODE_PROJECT=tsconfig-test.json tap --node-arg=-r --node-arg=ts-node/register ./test/*.test.{js,ts} -R spec --timeout=900 && jest --ci --runInBand",
+    "test": "npm run test:pysrc && npm run test:tap && npm run test:jest",
+    "test:tap": "cross-env TS_NODE_PROJECT=tsconfig-test.json tap --node-arg=-r --node-arg=ts-node/register ./test/**/*.test.{js,ts} -R spec --timeout=900",
+    "test:jest": "jest",
     "test:pysrc": "python -m unittest discover pysrc",
     "lint": "npm run build-tests && npm run format:check && eslint --cache '{lib,test}/**/*.{js,ts}'"
   },
@@ -23,6 +24,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@snyk/cli-interface": "^2.0.3",
+    "snyk-poetry-lockfile-parser": "^1.1.0",
     "tmp": "0.0.33"
   },
   "devDependencies": {
@@ -30,18 +32,19 @@
     "@types/jest": "^24.9.0",
     "@types/node": "8.10.60",
     "@types/tmp": "^0.1.0",
-    "@typescript-eslint/eslint-plugin": "^1.13.0",
-    "@typescript-eslint/parser": "^1.13.0",
+    "@typescript-eslint/eslint-plugin": "^3.8.0",
+    "@typescript-eslint/parser": "^3.8.0",
     "cross-env": "^5.2.0",
-    "eslint": "^5.16.0",
-    "eslint-config-prettier": "^6.0.0",
-    "jest": "^24.9.0",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.11.0",
+    "jest": "^25.5.4",
+    "jest-diff": "^25.5.0",
     "jest-junit": "^10.0.0",
-    "prettier": "1.19.1",
+    "prettier": "^1.19.1",
     "sinon": "^2.3.2",
     "tap": "^12.6.1",
-    "ts-jest": "^24.3.0",
-    "ts-node": "^8.1.0",
-    "typescript": "^3.4.5"
+    "ts-jest": "^25.5.1",
+    "ts-node": "^8.10.2",
+    "typescript": "^3.9.7"
   }
 }

--- a/test/matchers/dep-graph.ts
+++ b/test/matchers/dep-graph.ts
@@ -1,0 +1,36 @@
+import * as depGraphLib from '@snyk/dep-graph';
+import diff from 'jest-diff';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      toEqualDepGraph(expected: depGraphLib.DepGraph): R;
+    }
+    interface Expect {
+      toEqualDepGraph(expected: depGraphLib.DepGraph): void;
+    }
+  }
+}
+
+export function toEqualDepGraph(
+  received: depGraphLib.DepGraph,
+  expected: depGraphLib.DepGraph
+): jest.CustomMatcherResult {
+  // Diff dep-graph data. This will display ordering differences
+  // but it should be enough to get a rough idea of the failure
+  const getDiff = () =>
+    diff(expected.toJSON(), received.toJSON(), { expand: false });
+
+  if (received.equals(expected)) {
+    return {
+      message: () => `expected depGraphs not to be equal\n\n${getDiff()}`,
+      pass: true,
+    };
+  } else {
+    return {
+      message: () => `expected depGraphs to be equal\n\n${getDiff()}`,
+      pass: false,
+    };
+  }
+}

--- a/test/matchers/setup.ts
+++ b/test/matchers/setup.ts
@@ -1,0 +1,5 @@
+import { toEqualDepGraph } from './dep-graph';
+
+expect.extend({
+  toEqualDepGraph,
+});

--- a/test/system/inspect-provenance.test.ts
+++ b/test/system/inspect-provenance.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { test } from 'tap';
-import { chdirWorkspaces, activateVirtualenv } from './test-utils';
+import { chdirWorkspaces, activateVirtualenv } from '../test-utils';
 
-import pluginImpl = require('../lib');
+import pluginImpl = require('../../lib');
 
 const pipAppExpectedDependenciesOnlyProvenance = {
   django: {

--- a/test/system/inspect.spec.ts
+++ b/test/system/inspect.spec.ts
@@ -1,0 +1,35 @@
+import { inspect } from '../../lib';
+import { chdirWorkspaces } from '../test-utils';
+import { DepGraphBuilder } from '@snyk/dep-graph';
+
+// TODO: jestify tap tests in ./inspect.test.js here
+describe('inspect', () => {
+  it('should return expected dependencies for poetry-app', async () => {
+    const workspace = 'poetry-app';
+    chdirWorkspaces(workspace);
+
+    const result = await inspect('.', 'pyproject.toml');
+    expect(result).toMatchObject({
+      plugin: {
+        name: 'snyk-python-plugin',
+        runtime: expect.any(String), // any version of Python
+        targetFile: 'pyproject.toml',
+      },
+      package: null, // no dep-tree
+      dependencyGraph: {}, // match any dep-graph (equality checked below)
+    });
+
+    const builder = new DepGraphBuilder(
+      { name: 'poetry' },
+      { name: 'poetry-fixtures-project', version: '0.1.0' }
+    );
+    const expected = builder
+      .addPkgNode({ name: 'jinja2', version: '2.11.2' }, 'jinja2')
+      .connectDep(builder.rootNodeId, 'jinja2')
+      .addPkgNode({ name: 'MarkupSafe', version: '1.1.1' }, 'MarkupSafe')
+      .connectDep('jinja2', 'MarkupSafe')
+      .build();
+
+    expect(result.dependencyGraph).toEqualDepGraph(expected);
+  });
+});

--- a/test/system/inspect.test.js
+++ b/test/system/inspect.test.js
@@ -2,9 +2,9 @@ const test = require('tap').test;
 const fs = require('fs');
 const sinon = require('sinon');
 
-const plugin = require('../lib');
-const subProcess = require('../lib/dependencies/sub-process');
-const testUtils = require('./test-utils');
+const plugin = require('../../lib');
+const subProcess = require('../../lib/dependencies/sub-process');
+const testUtils = require('../test-utils');
 const os = require('os');
 
 const chdirWorkspaces = testUtils.chdirWorkspaces;

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -56,6 +56,7 @@ function activateVirtualenv(venvName: string) {
 function deactivateVirtualenv() {
   if (getActiveVenvName() === null) {
     console.warn('Attempted to deactivate a virtualenv when none was active.');
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     return () => {};
   }
 
@@ -98,6 +99,7 @@ function ensureVirtualenv(venvName: string) {
 }
 
 function createVenv(venvDir: string) {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   let revert = () => {};
   if (process.env.VIRTUAL_ENV) {
     revert = deactivateVirtualenv();

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["**/*.ts", "setup.ts"]
+  "include": ["**/*.ts"]
 }

--- a/test/unit/build-args.spec.ts
+++ b/test/unit/build-args.spec.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { buildArgs } from '../lib/dependencies/inspect-implementation';
+import { buildArgs } from '../../lib/dependencies/inspect-implementation';
 
 describe('build args', () => {
   it('should return expected args', () => {

--- a/test/unit/poetry.spec.ts
+++ b/test/unit/poetry.spec.ts
@@ -1,0 +1,56 @@
+import { getPoetryDependencies } from '../../lib/dependencies/poetry';
+import * as path from 'path';
+import { FILENAMES } from '../../lib/types';
+import * as poetry from 'snyk-poetry-lockfile-parser';
+
+describe('getPoetryDepencies', () => {
+  it('should throw exception when manifest does not exist', async () => {
+    expect.assertions(1);
+    const root = 'rootPath';
+    const targetFile = 'non-existant-target-file';
+    try {
+      await getPoetryDependencies('python', root, targetFile);
+    } catch (e) {
+      const expectedPath = path.join(root, targetFile);
+      const expected = new Error(`Cannot find manifest file ${expectedPath}`);
+      expect(e).toEqual(expected);
+    }
+  });
+
+  it('should throw exception when lockfile does not exist', async () => {
+    expect.assertions(1);
+    const root = path.join(
+      __dirname,
+      '..',
+      'workspaces',
+      'poetry-app-without-lockfile'
+    );
+    const targetFile = 'pyproject.toml';
+    try {
+      await getPoetryDependencies('python', root, targetFile);
+    } catch (e) {
+      const expectedPath = path.join(root, FILENAMES.poetry.lockfile);
+      const expected = new Error(`Cannot find lockfile ${expectedPath}`);
+      expect(e).toEqual(expected);
+    }
+  });
+
+  it('should throw exception when lockfile parser throws exception', async () => {
+    expect.assertions(1);
+    const poetryError = new Error('some poetry error msg');
+    jest.spyOn(poetry, 'buildDepGraph').mockImplementation(() => {
+      throw poetryError;
+    });
+
+    const root = path.join(__dirname, '..', 'workspaces', 'poetry-app');
+    const targetFile = 'pyproject.toml';
+    try {
+      await getPoetryDependencies('python', root, targetFile);
+    } catch (e) {
+      const expected = new Error(
+        'Error processing poetry project. some poetry error msg'
+      );
+      expect(e).toEqual(expected);
+    }
+  });
+});

--- a/test/workspaces/poetry-app-without-lockfile/pyproject.toml
+++ b/test/workspaces/poetry-app-without-lockfile/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.poetry]
+name = "poetry-fixtures-project"
+version = "0.1.0"
+description = ""
+authors = []
+
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.5"
+jinja2 = "^2.11"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/test/workspaces/poetry-app/poetry.lock
+++ b/test/workspaces/poetry-app/poetry.lock
@@ -1,0 +1,67 @@
+[[package]]
+category = "main"
+description = "A very fast and expressive template engine."
+name = "jinja2"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.11.2"
+
+[package.dependencies]
+MarkupSafe = ">=0.23"
+
+[package.extras]
+i18n = ["Babel (>=0.8)"]
+
+[[package]]
+category = "main"
+description = "Safely add untrusted strings to HTML/XML markup."
+name = "markupsafe"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "1.1.1"
+
+[metadata]
+content-hash = "334f93c64cda8baa29b0312f779a4f3169d50207800fe21e306f8283a94f6618"
+lock-version = "1.0"
+python-versions = "~2.7 || ^3.5"
+
+[metadata.files]
+jinja2 = [
+    {file = "Jinja2-2.11.2-py2.py3-none-any.whl", hash = "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"},
+    {file = "Jinja2-2.11.2.tar.gz", hash = "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0"},
+]
+markupsafe = [
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-win32.whl", hash = "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-win_amd64.whl", hash = "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-macosx_10_6_intel.whl", hash = "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-win32.whl", hash = "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-win_amd64.whl", hash = "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
+    {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
+]

--- a/test/workspaces/poetry-app/pyproject.toml
+++ b/test/workspaces/poetry-app/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.poetry]
+name = "poetry-fixtures-project"
+version = "0.1.0"
+description = ""
+authors = []
+
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.5"
+jinja2 = "^2.11"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -6,6 +6,8 @@
     "noImplicitAny": false,
   },
   "include": [
-    "./lib/**/*", "./test/**/*"
+    "./lib/**/*",
+    "./test/**/*",
+    "./test/matchers/*.ts",
   ]
 }


### PR DESCRIPTION
- [x] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Detect poetry being used when target file is 'pyproject.toml' (poetry manifest).
Use snyk-poetry-lockfile-parser to return dep-graph.
Updated typescript and eslint devDependencies to fix lint.
Added custom dep-graph jest matcher to compare dep-graphs.
Moved tests into either 'unit' or 'system' and refactor setup to be
script (not tap test) that runs before all tests.
Downgrade jest-diff version used as seems incompatible with node8.