### PR TITLE
Feat/validate deps exist

### DIFF
--- a/pysrc/test_pip_resolve.py
+++ b/pysrc/test_pip_resolve.py
@@ -1,12 +1,14 @@
 # run with:
 # cd pysrc; python3 test_pip_resolve.py; cd ..
 
+from io import StringIO
+from contextlib import contextmanager
 from pip_resolve import satisfies_python_requirement, \
-                        matches_python_version, \
-                        matches_environment, \
-                        canonicalize_package_name
+    matches_python_version, \
+    matches_environment, \
+    canonicalize_package_name, \
+    get_requirements_list
 from collections import namedtuple
-
 import unittest
 
 try:
@@ -14,18 +16,21 @@ try:
 except:
     from unittest.mock import patch
 
+
 class TestStringMethods(unittest.TestCase):
 
     def test_canonicalize_package_name(self):
         # https://packaging.python.org/guides/distributing-packages-using-setuptools/#name
         self.assertEqual(canonicalize_package_name("Cool-Stuff"), "cool.stuff")
-        self.assertEqual(canonicalize_package_name("Cool--.--Stuff"), "cool.stuff")
-        self.assertEqual(canonicalize_package_name("Cool--__.__--Stuff"), "cool.stuff")
+        self.assertEqual(canonicalize_package_name(
+            "Cool--.--Stuff"), "cool.stuff")
+        self.assertEqual(canonicalize_package_name(
+            "Cool--__.__--Stuff"), "cool.stuff")
 
         self.assertEqual(canonicalize_package_name("cool.stuff"), "cool.stuff")
         self.assertEqual(canonicalize_package_name("COOL_STUFF"), "cool.stuff")
-        self.assertEqual(canonicalize_package_name("CoOl__-.-__sTuFF"), "cool.stuff")
-
+        self.assertEqual(canonicalize_package_name(
+            "CoOl__-.-__sTuFF"), "cool.stuff")
 
     def test_satisfies_python_requirement(self):
 
@@ -49,7 +54,6 @@ class TestStringMethods(unittest.TestCase):
 
             mock_sys.version_info = (3, 6)
             self.assertTrue(satisfies_python_requirement('==', '3.*'))
-
 
     def test_matches_python_version(self):
 
@@ -98,8 +102,8 @@ class TestStringMethods(unittest.TestCase):
 
             # BUG: Comments are not supported
             #mock_sys.version_info = (2, 7)
-            #req.line = "futures==3.2.0 ; python_version == '2.6' # or python_version == '2.7'"
-            #self.assertFalse(matches_python_version(req))
+            # req.line = "futures==3.2.0 ; python_version == '2.6' # or python_version == '2.7'"
+            # self.assertFalse(matches_python_version(req))
 
             # BUG: The 'and' case doesn't really make sesne but should be handled correctly
             mock_sys.version_info = (2, 7)
@@ -113,7 +117,6 @@ class TestStringMethods(unittest.TestCase):
             mock_sys.version_info = (2, 7)
             req.line = "futures==3.2.0; python_version == '2.6' and sys_platform == 'linux2'"
             self.assertFalse(matches_python_version(req))
-
 
     def test_matches_environment(self):
 
@@ -136,7 +139,7 @@ class TestStringMethods(unittest.TestCase):
 
             mock_sys.platform = "win2000"
             req.line = "futures==3.2.0; sys_platform == 'linux2'"
-            self.assertFalse    (matches_environment(req))
+            self.assertFalse(matches_environment(req))
 
             # BUG: Only == operator is supported in the moment
             # mock_sys.platform = "linux2"
@@ -148,6 +151,46 @@ class TestStringMethods(unittest.TestCase):
             # req.line = "futures==3.2.0; python_version == '2.6' and sys_platform == 'linux2'"
             # self.assertTrue(matches_environment(req))
 
+
+# class TestGetRequirementsList(unittest.TestCase):
+#     def test_no_deps_informative_error(self):
+#         # capture sys output on error
+#         import sys
+
+#         @contextmanager
+#         def captured_output():
+#             new_out, new_err = StringIO(), StringIO()
+#             old_out, old_err = sys.stdout, sys.stderr
+#             try:
+#                 sys.stdout, sys.stderr = new_out, new_err
+#                 yield sys.stdout, sys.stderr
+#             finally:
+#                 sys.stdout, sys.stderr = old_out, old_err
+
+#     # Check Pipfile with no key or value for packages or dev-packages errors properly
+#         empty_pipfile_path = 'test/workspaces/pipfile-empty/Pipfile'
+#         # expected_no_deps_exception = 'SystemExit: No requirements found.'
+#         self.assertRaises(SystemError, get_requirements_list,
+#                           empty_pipfile_path)
+
+#     # Check Pipfile with keys but no values for packages or dev-packages errors properly
+#         empty_keys_pipfile_path = 'test/workspaces/pipfile-empty-keys/Pipfile'
+#         # expected_no_deps_exception = 'SystemExit: No requirements found.'
+#         self.assertRaises(SystemError, get_requirements_list,
+#                           empty_keys_pipfile_path)
+
+#     # Check Pipfile with no packages, dev-packages but dev-deps flag is false, errors properly
+#         dev_deps_pipfile_path = 'test/workspaces/pipfile-dev-deps-only/Pipfile'
+#         # expected_dev_deps_only_exception = 'SystemExit: No requirements found. Note: dev-dependencies present but skipped as --dev flag is false.\n\nPlease try running on a package with dependencies.'
+#         self.assertRaises(SystemError, get_requirements_list,
+#                           dev_deps_pipfile_path)
+
+#     # Pipfile, no packages, with dev-packages & dev-deps flag is true, returns correct req list and no error
+#         import pipfile
+#         result = get_requirements_list(dev_deps_pipfile_path, dev_deps=True)
+#         self.assertEqual(len(result), 4)
+#         for req in result:
+#             self.assertIsInstance(req, pipfile.PipfileRequirement)
 
 
 if __name__ == '__main__':

--- a/test/workspaces/pipfile-dev-deps-only/Pipfile
+++ b/test/workspaces/pipfile-dev-deps-only/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+python-etcd = ">=0.4,<0.5"
+testtools = "*"
+"Jinja2" = { version = "*" }
+"Django-Select2" = { version = "==6.0.1" }
+
+[requires]

--- a/test/workspaces/pipfile-dev-deps-only/README
+++ b/test/workspaces/pipfile-dev-deps-only/README
@@ -1,0 +1,2 @@
+This is a small pipenv-based config with no dependencies
+definitions but with some dev dependencies, based on pip-app and the pipenv example files.

--- a/test/workspaces/pipfile-empty-keys/Pipfile
+++ b/test/workspaces/pipfile-empty-keys/Pipfile
@@ -1,0 +1,10 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]

--- a/test/workspaces/pipfile-empty-keys/README
+++ b/test/workspaces/pipfile-empty-keys/README
@@ -1,0 +1,2 @@
+This is a small pipenv-based config with no dependencies definitions
+or dev dependencies, based on pip-app and the pipenv example files.

--- a/test/workspaces/pipfile-empty/Pipfile
+++ b/test/workspaces/pipfile-empty/Pipfile
@@ -1,0 +1,6 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[requires]

--- a/test/workspaces/pipfile-empty/README
+++ b/test/workspaces/pipfile-empty/README
@@ -1,0 +1,2 @@
+This is a small pipenv-based config containing no dependencies or
+dev-dependencies keys or values, based on pip-app and the pipenv example files.


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Handles edge case where user tests a Pipfile project with no dependencies, or with only dev-deps but no --dev-deps flag; throws informative error instead of just exiting silently without informing user why.
Next I'll be replicating this in pip-deps.

#### What are the relevant tickets?
Addresses https://snyk.zendesk.com/agent/tickets/6872

#### Screenshots
<img width="1259" alt="Screenshot 2020-10-27 at 16 54 38" src="https://user-images.githubusercontent.com/62237867/97334890-23745980-1875-11eb-8f04-95d7049d2775.png">
