### PR TITLE
feat/empty manifest graceful error

### DIFF
--- a/lib/dependencies/inspect-implementation.ts
+++ b/lib/dependencies/inspect-implementation.ts
@@ -121,9 +121,17 @@ export async function inspectInstalledDeps(
       ],
       { cwd: root }
     );
+
     return JSON.parse(output) as legacyCommon.DepTree;
   } catch (error) {
     if (typeof error === 'string') {
+      const emptyManifestMsg = 'No dependencies detected in manifest.';
+      const noDependenciesDetected = error.includes(emptyManifestMsg);
+
+      if (noDependenciesDetected) {
+        throw new Error(emptyManifestMsg);
+      }
+
       if (error.indexOf('Required packages missing') !== -1) {
         let errMsg = error;
         if (path.basename(targetFile) === FILENAMES.pipenv.manifest) {
@@ -139,6 +147,7 @@ export async function inspectInstalledDeps(
         throw new Error(errMsg);
       }
     }
+
     throw error;
   } finally {
     tempDirObj.removeCallback();

--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -202,8 +202,11 @@ def get_requirements_list(requirements_file_path, dev_deps=False):
         req_list = list(parsed_reqs.get('packages', []))
         if dev_deps:
             req_list.extend(parsed_reqs.get('dev-packages', []))
-        for r in req_list:
-            r.provenance = (requirements_file_path, r.provenance[1], r.provenance[2])
+        if not req_list:
+            return []
+        else:
+            for r in req_list:
+                r.provenance = (requirements_file_path, r.provenance[1], r.provenance[2])
     elif os.path.basename(requirements_file_path) == 'setup.py':
         with open(requirements_file_path, 'r') as f:
             setup_py_file_content = f.read()
@@ -254,25 +257,29 @@ def create_dependencies_tree_by_req_file_path(requirements_file_path,
 
     # create a list of dependencies from the dependencies file
     required = get_requirements_list(requirements_file_path, dev_deps=dev_deps)
-    installed = [canonicalize_package_name(p) for p in dist_index]
-    top_level_requirements = []
-    missing_package_names = []
-    for r in required:
-        if canonicalize_package_name(r.name) not in installed:
-            missing_package_names.append(r.name)
-        else:
-            top_level_requirements.append(r)
-    if missing_package_names:
-        msg = 'Required packages missing: ' + (', '.join(missing_package_names))
-        if allow_missing:
-            sys.stderr.write(msg + "\n")
-        else:
-            sys.exit(msg)
+    if not required:
+        msg = 'No dependencies detected in manifest.'
+        sys.exit(msg)
+    else:
+        installed = [canonicalize_package_name(p) for p in dist_index]
+        top_level_requirements = []
+        missing_package_names = []
+        for r in required:
+            if canonicalize_package_name(r.name) not in installed:
+                missing_package_names.append(r.name)
+            else:
+                top_level_requirements.append(r)
+        if missing_package_names:
+            msg = 'Required packages missing: ' + (', '.join(missing_package_names))
+            if allow_missing:
+                sys.stderr.write(msg + "\n")
+            else:
+                sys.exit(msg)
 
-    # build a tree of dependencies
-    package_tree = create_tree_of_packages_dependencies(
-        dist_tree, top_level_requirements, requirements_file_path, allow_missing, only_provenance)
-    print(json.dumps(package_tree))
+        # build a tree of dependencies
+        package_tree = create_tree_of_packages_dependencies(
+            dist_tree, top_level_requirements, requirements_file_path, allow_missing, only_provenance)  
+        print(json.dumps(package_tree))
 
 
 def main():

--- a/test/system/inspect.test.js
+++ b/test/system/inspect.test.js
@@ -653,12 +653,11 @@ test('Pipfile package found conditionally based on python version', (t) => {
     .then(() => {
       return plugin.inspect('.', 'Pipfile');
     })
-    .then((result) => {
-      const pkg = result.package;
-      t.notOk(pkg.dependencies.black, 'black dep ignored');
-      t.notOk(pkg.dependencies.stdeb, 'stdeb dep ignored');
-
-      t.end();
+    .catch((error) => {
+      t.match(
+        normalize(error.message),
+        'No dependencies detected in manifest.'
+      );
     });
 });
 
@@ -1055,6 +1054,23 @@ test('package names with urls are skipped', (t) => {
         Object.keys(pkg.dependencies).length,
         1,
         '1 dependency was skipped'
+      );
+    });
+});
+
+test('inspect Pipfile with no deps or dev-deps exits with message', (t) => {
+  return Promise.resolve()
+    .then(() => {
+      chdirWorkspaces('pipfile-empty');
+      t.teardown(testUtils.activateVirtualenv('pip-app'));
+    })
+    .then(() => {
+      return plugin.inspect('.', 'Pipfile');
+    })
+    .catch((error) => {
+      t.match(
+        normalize(error.message),
+        'No dependencies detected in manifest.'
       );
     });
 });

--- a/test/workspaces/pipfile-empty/Pipfile
+++ b/test/workspaces/pipfile-empty/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+
+[requires]
+python_version = "2.7"


### PR DESCRIPTION
Handles edge case where user tests a Pipfile project with no dependencies, or with only dev-deps but no --dev-deps flag; throws informative error instead of just exiting silently without informing user why.

![image](https://user-images.githubusercontent.com/40601533/98542009-eeb2ca00-2298-11eb-8bcd-48881ef30b55.png)

https://github.com/snyk/snyk-python-plugin/pull/114