### PR TITLE
fix: bump poetry parser plugin 

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@snyk/cli-interface": "^2.0.3",
-    "snyk-poetry-lockfile-parser": "^1.1.0",
+    "snyk-poetry-lockfile-parser": "^1.1.1",
     "tmp": "0.0.33"
   },
   "devDependencies": {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Bump snyk-poetry-lockfile-parser version to include auto-resolving dependencies with underscores to hyphens