### PR TITLE
fix: bump poetry parser version to include multiple fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@snyk/cli-interface": "^2.0.3",
-    "snyk-poetry-lockfile-parser": "^1.1.2",
+    "snyk-poetry-lockfile-parser": "^1.1.4",
     "tmp": "0.0.33"
   },
   "devDependencies": {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Bumps the poetry parser version to include the following fixes:
- Stop parser from trying to look up packages not propagated to the lockfile (wheel, distributed, pip,  setuptools)
- Stop parser from failing when failing to locate dependency in lockfile and instead log a warning. This could be because of python requirements allowing it in the manifest but not actually installing it and adding a lockfile entry or because of how Poetry treats the use of underscores and hyphens when installing packages
- Reversed PR that introduced swapping underscores in manifest for hyphens in lockfile. This was due to a misunderstanding of how Poetry worked and is remediated by the above.

#### What are the relevant tickets?
[LOKI-174](https://snyksec.atlassian.net/browse/LOKI-174)
[LOKI-175](https://snyksec.atlassian.net/browse/LOKI-175)
[LOKI-187](https://snyksec.atlassian.net/browse/LOKI-187)

