### PR TITLE
fix: support --file (and --all-projects) for Pipfile (133)

### DIFF
--- a/lib/dependencies/index.ts
+++ b/lib/dependencies/index.ts
@@ -43,7 +43,6 @@ export async function getDependencies(
     }
     command = 'pipenv';
     baseargs = ['run', 'python'];
-
   }
 
   const [plugin, pkg] = await Promise.all([

--- a/lib/dependencies/index.ts
+++ b/lib/dependencies/index.ts
@@ -43,11 +43,6 @@ export async function getDependencies(
     }
     command = 'pipenv';
     baseargs = ['run', 'python'];
-    // Pipenv assumes it is in the directory with the Pipfile
-    // --file generates a phantom pipfile if it's not
-    root = path.dirname(targetFile)
-    // and drop the directory name from the targetFile path
-    targetFile = path.basename(targetFile)
 
   }
 

--- a/lib/dependencies/index.ts
+++ b/lib/dependencies/index.ts
@@ -43,6 +43,12 @@ export async function getDependencies(
     }
     command = 'pipenv';
     baseargs = ['run', 'python'];
+    // Pipenv assumes it is in the directory with the Pipfile
+    // --file generates a phantom pipfile if it's not
+    root = path.dirname(targetFile)
+    // and drop the directory name from the targetFile path
+    targetFile = path.basename(targetFile)
+
   }
 
   const [plugin, pkg] = await Promise.all([

--- a/lib/dependencies/inspect-implementation.ts
+++ b/lib/dependencies/inspect-implementation.ts
@@ -167,7 +167,8 @@ export async function inspectInstalledDeps(
 // targetfile we will still fail however
 export function getPythonEnv(targetFile: string) {
   if ( path.basename(targetFile) === 'Pipfile') {
-    return {...process.env, "PIPENV_PIPFILE": targetFile }
+    const envOverrides = {"PIPENV_PIPFILE": targetFile, "PIPENV_IGNORE_VIRTUALENVS": "1" }
+    return {...process.env, ...envOverrides }
   } else {
     return process.env
   } 

--- a/test/system/inspect.test.js
+++ b/test/system/inspect.test.js
@@ -909,6 +909,62 @@ const pipenvAppExpectedDependencies = {
   },
 };
 
+test('inspect Pipfile in nested directory', (t) => {
+  return Promise.resolve()
+    .then(() => {
+      chdirWorkspaces('pipfile-nested-dirs');
+      t.teardown(testUtils.activateVirtualenv('pip-app-nested'));
+    })
+    .then(() => {
+      return plugin.inspect('.', 'nested/directory/Pipfile');
+    })
+    .then((result) => {
+      const plugin = result.plugin;
+      const pkg = result.package;
+
+      t.equal(plugin.targetFile, 'Pipfile', 'Pipfile targetfile');
+
+      t.test('package dependencies', (t) => {
+        t.notOk(pkg.dependencies['django'], 'django skipped (editable)');
+
+        t.match(
+          pkg.dependencies['django-select2'],
+          {
+            name: 'django-select2',
+            version: '6.0.1',
+            dependencies: {
+              'django-appconf': {
+                name: 'django-appconf',
+              },
+            },
+          },
+          'django-select2 looks ok'
+        );
+
+        t.match(
+          pkg.dependencies['python-etcd'],
+          {
+            name: 'python-etcd',
+            version: /^0\.4.*$/,
+          },
+          'python-etcd looks ok'
+        );
+
+        t.notOk(
+          pkg.dependencies['e1839a8'],
+          'dummy local package skipped (editable)'
+        );
+
+        t.ok(pkg.dependencies['jinja2'] !== undefined, 'jinja2 found');
+        t.ok(pkg.dependencies['testtools'] !== undefined, 'testtools found');
+
+        t.end();
+      });
+
+      t.end();
+    });
+});
+
 test('inspect pipenv app with user-created virtualenv', (t) => {
   return Promise.resolve()
     .then(() => {

--- a/test/workspaces/pipfile-nested-dirs/README
+++ b/test/workspaces/pipfile-nested-dirs/README
@@ -1,0 +1,5 @@
+This is a small pipenv-based config with a variety of types of dependency
+defintions, based on pip-app and the pipenv example files.
+
+This puts the Pipfile in a nested/directory/ to ensure that we can handle
+cwd changes properly (issue 133)

--- a/test/workspaces/pipfile-nested-dirs/nested/directory/Pipfile
+++ b/test/workspaces/pipfile-nested-dirs/nested/directory/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+python-etcd = ">=0.4,<0.5"
+testtools = "*"
+"Jinja2" = { version = "*" }
+django = { git = 'https://github.com/django/django.git', ref = '1.6.1', editable = true }
+"Django-Select2" = { version = "==6.0.1" }
+"e1839a8" = {path = ".", editable = true}
+
+[dev-packages]
+
+[requires]


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Changes the root and targetFile when scanning a Pipfile to ensure that Pipenv behaves properly
Now if given --file=foo/bar/Pipfile the root is changed to $pwd/foo/bar and targetFile to Pipfile
Given how the subprocess is spawned, this now ensure that the pipenv command is run in the directory
containing the pipfile instead of outside.

An alternative would be to set PIPENV_PIPFILE env variable with the path to Pipfile but this has the
added benefit of letting Pipenv run how it assumes it should be: in a directory with a Pipfile or
a sub directory of one containing, not above a Pipfile

This method also preserves the original behavior of scanning the Pipfile in $cwd because in that
case the path.dirname(targetFile) is the same as root, and path.basename(targetFile) is the same
as targetFile already

#### How should this be manually tested?

Try reproduction steps in #133 
