### PR TITLE
fix: Remove unneccessary CI contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,14 +131,12 @@ workflows:
     jobs:
       - install:
           name: Install
-          context: nodejs-install
           filters:
             branches:
               ignore:
                 - master
       - lint:
           name: Lint
-          context: nodejs-install
           requires:
             - Install
           filters:


### PR DESCRIPTION
These CI contexts aren't actually needed to pull in any deps, so lets just remove them