### PR TITLE
fix: make transitive deps lowercase

### DIFF
--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -81,7 +81,7 @@ def create_tree_of_packages_dependencies(
                 continue
 
             child_package = {
-                NAME: child_dist.project_name,
+                NAME: child_dist.project_name.lower(),
                 VERSION: child_dist.installed_version,
             }
 


### PR DESCRIPTION
This is to fix a bug where we flag multiple licenses for the same node due to case sensitivity

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This is to fix a bug where we flag multiple licenses for the same node due to case sensitivity

Example: 

If we have `django` (lowercase) as a direct dependency in a project with `Django` as a transitive dependency they will be treated as separate packages.