### PR TITLE
fix: use poetry-lock file as a target file for poetry project

### DIFF
--- a/lib/dependencies/index.ts
+++ b/lib/dependencies/index.ts
@@ -28,7 +28,7 @@ export async function getDependencies(
   const includeDevDeps = !!(options.dev || false);
 
   // handle poetry projects by parsing manifest & lockfile and return a dep-graph
-  if (path.basename(targetFile) === FILENAMES.poetry.manifest) {
+  if (path.basename(targetFile) === FILENAMES.poetry.lockfile) {
     return getPoetryDependencies(command, root, targetFile, includeDevDeps);
   }
 

--- a/lib/dependencies/inspect-implementation.ts
+++ b/lib/dependencies/inspect-implementation.ts
@@ -23,7 +23,7 @@ export function getMetaData(
         // specify targetFile only in case of Pipfile or setup.py
         targetFile: path
           .basename(targetFile)
-          .match(/^(Pipfile|setup\.py|pyproject\.toml)$/)
+          .match(/^(Pipfile|setup\.py|poetry\.lock)$/)
           ? targetFile
           : undefined,
       };

--- a/lib/dependencies/poetry.ts
+++ b/lib/dependencies/poetry.ts
@@ -11,10 +11,11 @@ export async function getPoetryDependencies(
   targetFile: string,
   includeDevDeps = false
 ): Promise<SinglePackageResult> {
-  const manifestPath = path.join(root, targetFile);
-  const baseDir = path.dirname(manifestPath);
-  const lockfilePath = path.join(baseDir, FILENAMES.poetry.lockfile);
+  const lockfilePath = path.join(root, targetFile);
+  const baseDir = path.dirname(lockfilePath);
+  const manifestPath = path.join(baseDir, FILENAMES.poetry.manifest);
   const manifestExists = fs.existsSync(manifestPath);
+
   if (!manifestExists) {
     throw new Error('Cannot find manifest file ' + manifestPath);
   }

--- a/test/system/inspect.spec.ts
+++ b/test/system/inspect.spec.ts
@@ -1,6 +1,7 @@
 import { inspect } from '../../lib';
 import { chdirWorkspaces } from '../test-utils';
 import { DepGraphBuilder } from '@snyk/dep-graph';
+import { FILENAMES } from '../../lib/types';
 
 // TODO: jestify tap tests in ./inspect.test.js here
 describe('inspect', () => {
@@ -8,12 +9,12 @@ describe('inspect', () => {
     const workspace = 'poetry-app';
     chdirWorkspaces(workspace);
 
-    const result = await inspect('.', 'pyproject.toml');
+    const result = await inspect('.', FILENAMES.poetry.lockfile);
     expect(result).toMatchObject({
       plugin: {
         name: 'snyk-python-plugin',
         runtime: expect.any(String), // any version of Python
-        targetFile: 'pyproject.toml',
+        targetFile: FILENAMES.poetry.lockfile,
       },
       package: null, // no dep-tree
       dependencyGraph: {}, // match any dep-graph (equality checked below)

--- a/test/unit/poetry.spec.ts
+++ b/test/unit/poetry.spec.ts
@@ -11,7 +11,7 @@ describe('getPoetryDepencies', () => {
     try {
       await getPoetryDependencies('python', root, targetFile);
     } catch (e) {
-      const expectedPath = path.join(root, targetFile);
+      const expectedPath = path.join(root, FILENAMES.poetry.manifest);
       const expected = new Error(`Cannot find manifest file ${expectedPath}`);
       expect(e).toEqual(expected);
     }
@@ -25,7 +25,7 @@ describe('getPoetryDepencies', () => {
       'workspaces',
       'poetry-app-without-lockfile'
     );
-    const targetFile = 'pyproject.toml';
+    const targetFile = FILENAMES.poetry.lockfile;
     try {
       await getPoetryDependencies('python', root, targetFile);
     } catch (e) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

As a part of this PR we we will pass `poetry.lock` file to this plugin as opposed to `pyproject.toml`. This is because `pyproject.toml` is not a reliable manifest file (see https://github.com/snyk/snyk/issues/1802) and therefore we need to use `poetry.lock` as a traget file. This is a breaking change 

New published version has to be integrated into https://github.com/snyk/snyk/pull/1879

#### How should this be manually tested?

1. checkout this branch https://github.com/snyk/snyk/pull/1879
2. link snyk-python-plugin to snyk repo - make sure you are using the same node versions in both repos
3. run tests in https://github.com/snyk/snyk/pull/1879

#### What are the relevant tickets?

[LOKI-280](https://snyksec.atlassian.net/browse/LOKI-280)

