### PR TITLE
fix: override root node name for pip projects without name

### DIFF
--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -98,7 +98,7 @@ def create_tree_of_packages_dependencies(
                 name, version = setup_file.parse_name_and_version(setup_py_file.read())
 
         dir_as_root = {
-            NAME: name or os.path.basename(os.path.dirname(os.path.abspath(req_file_path))),
+            NAME: name or os.path.basename(os.path.dirname(os.path.abspath(req_file_path))) + '-SNYK-TEST',
             VERSION: version or DIR_VERSION,
             DEPENDENCIES: {},
             PACKAGE_FORMAT_VERSION: 'pip:0.0.1'

--- a/test/system/inspect-provenance.test.ts
+++ b/test/system/inspect-provenance.test.ts
@@ -73,7 +73,7 @@ test('inspect --only-provenance', async (t) => {
 
   t.test('package', async (t) => {
     t.ok(pkg, 'package');
-    t.equal(pkg.name, 'pip-app', 'name');
+    t.equal(pkg.name, 'pip-app-SNYK-TEST', 'name');
     t.equal(pkg.version, '0.0.0', 'version');
   });
 
@@ -141,7 +141,7 @@ test('inspect --only-provenance for Pipfile', async (t) => {
 
   t.test('package', async (t) => {
     t.ok(pkg, 'package');
-    t.equal(pkg.name, 'pipfile-pipapp', 'name');
+    t.equal(pkg.name, 'pipfile-pipapp-SNYK-TEST', 'name');
     t.equal(pkg.version, '0.0.0', 'version');
   });
 

--- a/test/system/inspect.test.js
+++ b/test/system/inspect.test.js
@@ -300,7 +300,7 @@ test('inspect', (t) => {
 
       t.test('package', (t) => {
         t.ok(pkg, 'package');
-        t.equal(pkg.name, 'pip-app', 'name');
+        t.equal(pkg.name, 'pip-app-SNYK-TEST', 'name');
         t.equal(pkg.version, '0.0.0', 'version');
         t.end();
       });
@@ -437,7 +437,7 @@ test('transitive dep not installed, but with allowMissing option', (t) => {
 
       t.test('package', (t) => {
         t.ok(pkg, 'package');
-        t.equal(pkg.name, 'pip-app', 'name');
+        t.equal(pkg.name, 'pip-app-SNYK-TEST', 'name');
         t.equal(pkg.version, '0.0.0', 'version');
         t.end();
       });
@@ -546,7 +546,7 @@ test('deps not installed, but with allowMissing option', (t) => {
 
       t.test('package', (t) => {
         t.ok(pkg, 'package');
-        t.equal(pkg.name, 'pip-app-deps-not-installed', 'name');
+        t.equal(pkg.name, 'pip-app-deps-not-installed-SNYK-TEST', 'name');
         t.equal(pkg.version, '0.0.0', 'version');
         t.end();
       });
@@ -753,7 +753,7 @@ test('deps with options', (t) => {
 
       t.test('package', (t) => {
         t.ok(pkg, 'package');
-        t.equal(pkg.name, 'pip-app-with-options', 'name');
+        t.equal(pkg.name, 'pip-app-with-options-SNYK-TEST', 'name');
         t.equal(pkg.version, '0.0.0', 'version');
         t.end();
       });


### PR DESCRIPTION
#### What does this PR do?
There has been name clashing with an existing Pypi package which flags as having a vulnerability when it doesn't. To overcome this the PR changes the name of the root node to avoid the clashing of names.

Before - 2 vulnerabilities flagged because root node is `sphinx@0.0.0` with known [vulnerability](https://app.snyk.io/vuln/SNYK-PYTHON-SPHINX-570772):
![Screenshot 2021-05-25 at 09 57 37](https://user-images.githubusercontent.com/44169561/119470019-cfb0ec80-bd3f-11eb-9811-6d862f7e9949.png)


After - no vulnerability is found because root node is `sphinx-SNYK-TEST@0.0.0` which is not a known package and hence doesn't have any vulenrabilities:
![Screenshot 2021-05-25 at 09 56 26](https://user-images.githubusercontent.com/44169561/119470023-d0e21980-bd3f-11eb-80a7-4ea32a990f23.png)


Implications: this will override names of all already existing python project names and all the new projects too. The new name will have form `<directory_name>-SNYK-TEST`

![Screenshot 2021-05-24 at 17 57 35](https://user-images.githubusercontent.com/44169561/119465787-e8b79e80-bd3b-11eb-80f6-f15882eb63aa.png)

Reasoning why we went for this solution:
In python projects managed by `pip` we create a tree with root node corresponding to folder name, e.g.
```
folderName
  |_ dep1
  |_ dep2
     |_ dep2_1
     |_ dep2_2
  |_ dep3
```

This root node is, however, never meant to be considered a valid package. Regardless we still need root node even though it's not a real dependency because our [data structures](https://github.com/snyk/dep-graph) (both dep tree and dep graph) require root node. By convention we still pretend that root node is a valid package and assign version `0.0.0` to it for the sake of completeness of our data structure. Phoenix (service responsible for determining vulnerabilities) will handle gracefully if package name is not found in vulnerability database (regardless if it's a real package name or made up name).

### Manually testing
To manually test:
1. `npm link && npm run build`  // in snyk-python-plugin
2. `npm link snyk-python-plugin && npm run build` // in snyk cli repository
3. Clone https://github.com/OPAE/opae-sdk/blob/master/doc/sphinx/requirements.txt
4. `cd doc/sphinx`
5. pip install -r requirements.txt
6. `location/to/snyk/repo/dist/cli/index.js test --command=python3` // in opae-sdk/doc/sphinx

### Next steps
- bump snyk-python plugin in [pip-deps](https://github.com/snyk/pip-deps/blob/27e9c79ee9a4a37439bb8b65ad14bcb76249d1c9/package.json#L41) & [snyk cli](https://github.com/snyk/snyk/blob/6e7fccf89250160144b13bd497c66ec7da9ef66e/package.json#L130) 

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/LOKI-43

