### PR TITLE
fix: handle snyk being ran from root dir

### DIFF
--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -91,20 +91,6 @@ def create_tree_of_packages_dependencies(
             root_package[DEPENDENCIES][child_dist.project_name] = child_package
         return root_package
 
-    def create_dir_as_root():
-        name, version = None, None
-        if os.path.basename(req_file_path) == 'setup.py':
-            with open(req_file_path, "r") as setup_py_file:
-                name, version = setup_file.parse_name_and_version(setup_py_file.read())
-
-        dir_as_root = {
-            NAME: name or os.path.basename(os.path.dirname(os.path.abspath(req_file_path))),
-            VERSION: version or DIR_VERSION,
-            DEPENDENCIES: {},
-            PACKAGE_FORMAT_VERSION: 'pip:0.0.1'
-        }
-        return dir_as_root
-
     def create_package_as_root(package, dir_as_root):
         package_as_root = {
             NAME: package.project_name.lower(),
@@ -112,7 +98,7 @@ def create_tree_of_packages_dependencies(
             VERSION: package._obj._version,
         }
         return package_as_root
-    dir_as_root = create_dir_as_root()
+    dir_as_root = create_dir_as_root(req_file_path, NAME, VERSION, DIR_VERSION, DEPENDENCIES, PACKAGE_FORMAT_VERSION)
     for package in packages_as_dist_obj:
         package_as_root = create_package_as_root(package, dir_as_root)
         if only_provenance:
@@ -121,6 +107,20 @@ def create_tree_of_packages_dependencies(
         else:
             package_tree = create_children_recursive(package_as_root, key_tree, set([]))
             dir_as_root[DEPENDENCIES][package_as_root[NAME]] = package_tree
+    return dir_as_root
+
+def create_dir_as_root(req_file_path, NAME, VERSION, DIR_VERSION, DEPENDENCIES, PACKAGE_FORMAT_VERSION):
+    name, version = None, None
+    if os.path.basename(req_file_path) == 'setup.py':
+        with open(req_file_path, "r") as setup_py_file:
+            name, version = setup_file.parse_name_and_version(setup_py_file.read())
+
+    dir_as_root = {
+        NAME: name or os.path.basename(os.path.dirname(os.path.abspath(req_file_path))) or '_root',
+        VERSION: version or DIR_VERSION,
+        DEPENDENCIES: {},
+        PACKAGE_FORMAT_VERSION: 'pip:0.0.1'
+    }
     return dir_as_root
 
 def satisfies_python_requirement(parsed_operator, py_version_str):

--- a/pysrc/test_pip_resolve.py
+++ b/pysrc/test_pip_resolve.py
@@ -4,7 +4,8 @@
 from pip_resolve import satisfies_python_requirement, \
                         matches_python_version, \
                         matches_environment, \
-                        canonicalize_package_name
+                        canonicalize_package_name, \
+                        create_dir_as_root
 from collections import namedtuple
 
 import unittest
@@ -15,6 +16,16 @@ except:
     from unittest.mock import patch
 
 class TestStringMethods(unittest.TestCase):
+
+    def test_create_dir_as_root(self):
+        DEPENDENCIES = 'dependencies'
+        VERSION = 'version'
+        NAME = 'name'
+        DIR_VERSION = '0.0.0'
+        PACKAGE_FORMAT_VERSION = 'packageFormatVersion'
+
+        self.assertEqual(create_dir_as_root("/requirements.txt", NAME, VERSION, DIR_VERSION, DEPENDENCIES, PACKAGE_FORMAT_VERSION)['name'], "_root")
+        self.assertEqual(create_dir_as_root("/some_dir/requirements.txt", NAME, VERSION, DIR_VERSION, DEPENDENCIES, PACKAGE_FORMAT_VERSION)['name'], "some_dir")
 
     def test_canonicalize_package_name(self):
         # https://packaging.python.org/guides/distributing-packages-using-setuptools/#name


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adds a fallback for when name is "" in the plugin due to snyk being ran from the users "/" directory