### PR TITLE
fix: project name to override empty string from running in root dir

### DIFF
--- a/lib/dependencies/index.ts
+++ b/lib/dependencies/index.ts
@@ -57,5 +57,16 @@ export async function getDependencies(
       options.args
     ),
   ]);
+
+  if (!pkg.name) {
+    return {
+      plugin,
+      package: {
+        ...pkg,
+        ...(options['project-name'] && { name: options['project-name'] }),
+      },
+    };
+  }
+
   return { plugin, package: pkg };
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

An error is thrown when testing a python project from root due to the name being resolved to "" this allows this to be avoided by adding the --project-name flag
