### PR TITLE
feat: improve error message for pip manifests failures

### DIFF
--- a/lib/dependencies/inspect-implementation.ts
+++ b/lib/dependencies/inspect-implementation.ts
@@ -5,6 +5,7 @@ import * as tmp from 'tmp';
 import * as subProcess from './sub-process';
 import { legacyCommon } from '@snyk/cli-interface';
 import { FILENAMES } from '../types';
+import { EmptyManifestError, RequiredPackagesMissingError } from '../errors';
 
 const returnedTargetFile = (originalTargetFile) => {
   const basename = path.basename(originalTargetFile);
@@ -138,7 +139,10 @@ export async function inspectInstalledDeps(
           args
         ),
       ],
-      { cwd: root, env: pythonEnv }
+      {
+        cwd: root,
+        env: pythonEnv,
+      }
     );
 
     return JSON.parse(output) as legacyCommon.DepTree;
@@ -148,7 +152,7 @@ export async function inspectInstalledDeps(
       const noDependenciesDetected = error.includes(emptyManifestMsg);
 
       if (noDependenciesDetected) {
-        throw new Error(emptyManifestMsg);
+        throw new EmptyManifestError(emptyManifestMsg);
       }
 
       if (error.indexOf('Required packages missing') !== -1) {
@@ -163,7 +167,8 @@ export async function inspectInstalledDeps(
           errMsg += '\nPlease run `pip install -r ' + targetFile + '`.';
         }
         errMsg += ' If the issue persists try again with --skip-unresolved.';
-        throw new Error(errMsg);
+
+        throw new RequiredPackagesMissingError(errMsg);
       }
     }
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,18 @@
+export enum PythonPluginErrorNames {
+  EMPTY_MANIFEST_ERROR = 'EMPTY_MANIFEST_ERROR',
+  REQUIRED_PACKAGES_MISSING_ERROR = 'REQUIRED_PACKAGES_MISSING_ERROR',
+}
+
+export class EmptyManifestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = PythonPluginErrorNames.EMPTY_MANIFEST_ERROR;
+  }
+}
+
+export class RequiredPackagesMissingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = PythonPluginErrorNames.REQUIRED_PACKAGES_MISSING_ERROR;
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,3 +2,9 @@ export {
   getDependencies as inspect,
   PythonInspectOptions,
 } from './dependencies';
+
+export {
+  EmptyManifestError,
+  RequiredPackagesMissingError,
+  PythonPluginErrorNames,
+} from './errors';


### PR DESCRIPTION
Improve some error messaging in the plugin. Make sure to export the definitions. The idea is that consumers of a package (such as `pip-deps`) will be able to recognise more specific errors and act on them.