### PR TITLE
fix: support quoted keys in inline tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@snyk/cli-interface": "^2.0.3",
-    "snyk-poetry-lockfile-parser": "^1.1.6",
+    "snyk-poetry-lockfile-parser": "^1.1.7",
     "tmp": "0.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
updates the plugin to include changes in https://github.com/snyk/snyk-poetry-lockfile-parser/pull/15