### PR TITLE
fix(poetry): capture error message

### DIFF
--- a/lib/dependencies/poetry.ts
+++ b/lib/dependencies/poetry.ts
@@ -40,7 +40,7 @@ export async function getPoetryDependencies(
     };
   } catch (error) {
     throw new Error(
-      'Error processing poetry project. ' + error.message || error
+      'Error processing poetry project. ' + (error.message || error)
     );
   }
 }


### PR DESCRIPTION
Even if the error is a string and not an object
We observed an error that was just a string (probably coming from a call like `throw 'some error'` that was swallowed as an `undefined`

```
Monitoring /project...

Error processing poetry project. undefined
    at monitor (/snapshot/snyk/dist/cli/webpack:/snyk/src/cli/commands/monitor/index.ts:292:9)
    at runCommand (/snapshot/snyk/dist/cli/webpack:/snyk/src/cli/index.ts:58:25)
    at main (/snapshot/snyk/dist/cli/webpack:/snyk/src/cli/index.ts:316:4)
```

In this case, it was `python: not found`