### PR TITLE
feat: add option "projectName" flag to customize root node and package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ venv/
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+.DS_Store

--- a/lib/dependencies/build-dep-graph.ts
+++ b/lib/dependencies/build-dep-graph.ts
@@ -18,7 +18,8 @@ type Dependencies = {
 };
 
 export function buildDepGraph(
-  partialDepTree: PartialDepTree
+  partialDepTree: PartialDepTree,
+  projectName?: string
 ): Promise<DepGraph> {
   const packageToDepTreeMap = new Map<PackageName, PartialDepTree>();
 
@@ -45,6 +46,8 @@ export function buildDepGraph(
     }
     dependencies[key] = packageToDepTreeMap.get(key);
   });
+
+  if (projectName) partialDepTree.name = projectName;
 
   return depTreeToGraph(partialDepTree as DepTree, 'pip');
 }

--- a/lib/dependencies/index.ts
+++ b/lib/dependencies/index.ts
@@ -10,6 +10,7 @@ export interface PythonInspectOptions {
   command?: string; // `python` command override
   allowMissing?: boolean; // Allow skipping packages that are not found in the environment.
   args?: string[];
+  projectName?: string; // Allow providing a project name for the root node and package
 }
 
 type Options = api.SingleSubprojectInspectOptions & PythonInspectOptions;
@@ -54,7 +55,8 @@ export async function getDependencies(
       targetFile,
       options.allowMissing || false,
       includeDevDeps,
-      options.args
+      options.args,
+      options.projectName
     ),
   ]);
   return { plugin, dependencyGraph };

--- a/lib/dependencies/inspect-implementation.ts
+++ b/lib/dependencies/inspect-implementation.ts
@@ -118,7 +118,8 @@ export async function inspectInstalledDeps(
   targetFile: string,
   allowMissing: boolean,
   includeDevDeps: boolean,
-  args?: string[]
+  args?: string[],
+  projectName?: string
 ): Promise<DepGraph> {
   const tempDirObj = tmp.dirSync({
     unsafeCleanup: true,
@@ -147,7 +148,7 @@ export async function inspectInstalledDeps(
     );
 
     const result = JSON.parse(output) as PartialDepTree;
-    return buildDepGraph(result);
+    return buildDepGraph(result, projectName);
   } catch (error) {
     if (typeof error === 'string') {
       const emptyManifestMsg = 'No dependencies detected in manifest.';


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
when we used deptree, one could easily override the dep-tree's name with updating the name property.
in dep-graph this is not possible, so we need a way to override this.