### PR TITLE
fix: fix 'key psutil not found in packageToDepTreeMap' error

### DIFF
--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -84,7 +84,7 @@ def create_tree_of_packages_dependencies(
             if DEPENDENCIES not in root_package:
                 root_package[DEPENDENCIES] = {}
 
-            if child_project_name in all_packages_map:
+            if child_project_name in all_packages_map and child_project_name not in root_package[DEPENDENCIES]:
                 root_package[DEPENDENCIES][child_project_name] = 'true'
                 continue
 

--- a/test/system/inspect.test.js
+++ b/test/system/inspect.test.js
@@ -670,6 +670,29 @@ test('package installed conditionally based on python version', (t) => {
     });
 });
 
+test('should return correct package info when a single package has a dependency more than once', (t) => {
+  return Promise.resolve()
+    .then(() => {
+      chdirWorkspaces('pip-app-with-repeating-dependency');
+      const venvCreated = testUtils.ensureVirtualenv(
+        'pip-app-with-repeating-dependency'
+      );
+      t.teardown(
+        testUtils.activateVirtualenv('pip-app-with-repeating-dependency')
+      );
+      if (venvCreated) {
+        testUtils.pipInstall();
+      }
+    })
+    .then(() => {
+      return plugin.inspect('.', 'requirements.txt');
+    })
+    .then(async (result) => {
+      t.ok(result.dependencyGraph, 'graph generated');
+      t.end();
+    });
+});
+
 test('Pipfile package found conditionally based on python version', (t) => {
   return Promise.resolve()
     .then(() => {

--- a/test/workspaces/pip-app-with-repeating-dependency/requirements.txt
+++ b/test/workspaces/pip-app-with-repeating-dependency/requirements.txt
@@ -1,0 +1,2 @@
+# the gevent package  has 'psutil' twice as a dependency (probably with different requirements)
+gevent==21.1.2


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
In https://github.com/snyk/snyk-python-plugin/pull/159 we introduced a change to use dep graph instead of dep tree
In specific scenarios, we see a direct dependency more than once for a specific package.
This change will make sure we're setting it correctly
