### PR TITLE
fix: use node 14 for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
   release:
     <<: *defaults
     docker:
-      - image: node:10
+      - image: node:14
     steps:
       - checkout_and_merge
       - run:


### PR DESCRIPTION
#### What does this PR do?
Fix release by using required node version for semantic release

#### Any background context you want to provide?
Circle CI is failing on previous merge because we are using node version 10 in the python plugin.  https://app.circleci.com/pipelines/github/snyk/snyk-python-plugin/530/workflows/fbe18d07-eb34-4fac-8904-17003ec892e7/jobs/9627
