### PR TITLE
feat: allow empty manifest flag

### DIFF
--- a/lib/dependencies/index.ts
+++ b/lib/dependencies/index.ts
@@ -11,6 +11,7 @@ export interface PythonInspectOptions {
   allowMissing?: boolean; // Allow skipping packages that are not found in the environment.
   args?: string[];
   projectName?: string; // Allow providing a project name for the root node and package
+  allowEmpty?: boolean; // Allow manifest without dependencies (mostly for SCM)
 }
 
 type Options = api.SingleSubprojectInspectOptions & PythonInspectOptions;
@@ -55,6 +56,7 @@ export async function getDependencies(
       targetFile,
       options.allowMissing || false,
       includeDevDeps,
+      options.allowEmpty,
       options.args,
       options.projectName
     ),

--- a/lib/dependencies/inspect-implementation.ts
+++ b/lib/dependencies/inspect-implementation.ts
@@ -118,6 +118,7 @@ export async function inspectInstalledDeps(
   targetFile: string,
   allowMissing: boolean,
   includeDevDeps: boolean,
+  allowEmpty: boolean,
   args?: string[],
   projectName?: string
 ): Promise<DepGraph> {
@@ -136,6 +137,7 @@ export async function inspectInstalledDeps(
         ...buildArgs(
           targetFile,
           allowMissing,
+          allowEmpty,
           tempDirObj.name,
           includeDevDeps,
           args
@@ -196,6 +198,7 @@ export function getPythonEnv(targetFile: string) {
 export function buildArgs(
   targetFile: string,
   allowMissing: boolean,
+  allowEmpty: boolean,
   tempDirPath: string,
   includeDevDeps: boolean,
   extraArgs?: string[]
@@ -207,6 +210,9 @@ export function buildArgs(
   }
   if (allowMissing) {
     args.push('--allow-missing');
+  }
+  if (allowEmpty) {
+    args.push('--allow-empty');
   }
   if (includeDevDeps) {
     args.push('--dev-deps');

--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -253,7 +253,8 @@ def canonicalize_package_name(name):
 def create_dependencies_tree_by_req_file_path(requirements_file_path,
                                               allow_missing=False,
                                               dev_deps=False,
-                                              only_provenance=False):
+                                              only_provenance=False,
+                                              allow_empty=False):
     # get all installed packages
     pkgs = list(pkg_resources.working_set)
 
@@ -265,7 +266,7 @@ def create_dependencies_tree_by_req_file_path(requirements_file_path,
 
     # create a list of dependencies from the dependencies file
     required = get_requirements_list(requirements_file_path, dev_deps=dev_deps)
-    if not required:
+    if not required and not allow_empty:
         msg = 'No dependencies detected in manifest.'
         sys.exit(msg)
     else:
@@ -316,6 +317,9 @@ def main():
     parser.add_argument("--only-provenance",
         action="store_true",
         help="only return top level deps with provenance information")
+    parser.add_argument("--allow-empty",
+        action="store_true",
+        help="return empty dep tree instead of throwing")
     args = parser.parse_args()
 
     create_dependencies_tree_by_req_file_path(
@@ -323,6 +327,7 @@ def main():
         allow_missing=args.allow_missing,
         dev_deps=args.dev_deps,
         only_provenance=args.only_provenance,
+        allow_empty=args.allow_empty,
     )
 
 if __name__ == '__main__':

--- a/test/unit/build-args.spec.ts
+++ b/test/unit/build-args.spec.ts
@@ -3,10 +3,14 @@ import { buildArgs } from '../../lib/dependencies/inspect-implementation';
 
 describe('build args', () => {
   it('should return expected args', () => {
-    const result = buildArgs('requirements.txt', false, '../pysrc', false, [
-      '-argOne',
-      '-argTwo',
-    ]);
+    const result = buildArgs(
+      'requirements.txt',
+      false,
+      false,
+      '../pysrc',
+      false,
+      ['-argOne', '-argTwo']
+    );
     expect(result).toEqual([
       `..${path.sep}pysrc${path.sep}pip_resolve.py`,
       'requirements.txt',
@@ -16,10 +20,14 @@ describe('build args', () => {
   });
 
   it('should return expected args when allowMissing is true', () => {
-    const result = buildArgs('requirements.txt', true, '../pysrc', false, [
-      '-argOne',
-      '-argTwo',
-    ]);
+    const result = buildArgs(
+      'requirements.txt',
+      true,
+      false,
+      '../pysrc',
+      false,
+      ['-argOne', '-argTwo']
+    );
     expect(result).toEqual([
       `..${path.sep}pysrc${path.sep}pip_resolve.py`,
       'requirements.txt',
@@ -30,10 +38,14 @@ describe('build args', () => {
   });
 
   it('should return expected args when includeDevDeps is true', () => {
-    const result = buildArgs('requirements.txt', false, '../pysrc', true, [
-      '-argOne',
-      '-argTwo',
-    ]);
+    const result = buildArgs(
+      'requirements.txt',
+      false,
+      false,
+      '../pysrc',
+      true,
+      ['-argOne', '-argTwo']
+    );
     expect(result).toEqual([
       `..${path.sep}pysrc${path.sep}pip_resolve.py`,
       'requirements.txt',
@@ -44,10 +56,14 @@ describe('build args', () => {
   });
 
   it('should return expected args when allowMissing and includeDevDeps are true', () => {
-    const result = buildArgs('requirements.txt', true, '../pysrc', true, [
-      '-argOne',
-      '-argTwo',
-    ]);
+    const result = buildArgs(
+      'requirements.txt',
+      true,
+      false,
+      '../pysrc',
+      true,
+      ['-argOne', '-argTwo']
+    );
     expect(result).toEqual([
       `..${path.sep}pysrc${path.sep}pip_resolve.py`,
       'requirements.txt',


### PR DESCRIPTION
this change introduce "--allow-empty" flag, that doesn't throw "No dependencies found." error when manifest is empty.
