### PR TITLE
fix: when a line inside "requirements.txt" has more than one space

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
           command: npm run build
       - run:
           name: Release
-          command: npx semantic-release
+          command: npx semantic-release@15
 
 workflows:
   version: 2

--- a/pysrc/requirements/parser.py
+++ b/pysrc/requirements/parser.py
@@ -55,7 +55,7 @@ def parse(req_str_or_file):
             # unsupported
             continue
         elif line.startswith('-r') or line.startswith('--requirement'):
-            _, new_filename = line.split()
+            new_filename = line.split()[1]
             new_file_path = os.path.join(os.path.dirname(filename or '.'),
                                          new_filename)
             with open(new_file_path) as f:


### PR DESCRIPTION
today we fail for the following requirements line "-r req-something.txt # some comment" because of the way we split the line
this change will just take the second item in the line (right after the '-r' flag)

in addition, this will fix the release phase on circle