### PR TITLE
fix: fix key XXX not found in packageToDepTreeMap

### DIFF
--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -84,6 +84,9 @@ def create_tree_of_packages_dependencies(
             if DEPENDENCIES not in root_package:
                 root_package[DEPENDENCIES] = {}
 
+            if child_project_name in root_package[DEPENDENCIES]:
+                continue
+
             if child_project_name in all_packages_map and child_project_name not in root_package[DEPENDENCIES]:
                 root_package[DEPENDENCIES][child_project_name] = 'true'
                 continue


### PR DESCRIPTION
Since the last change of introducing packageToDepTreeMap, we're seeing some errors in logs of "key XXX not found in packageToDepTreeMap"
This happens because current implementation ignores "extras" property (i.e. requests['security']) and identify duplicate "requests" children.
this small change doesn't add support for "extras" property, but simply ignores it in a more graceful way (no regression here)