### PR TITLE
Normalized deps package name too

### DIFF
--- a/pysrc/utils.py
+++ b/pysrc/utils.py
@@ -1,5 +1,6 @@
 from importlib import import_module
 from operator import attrgetter
+import re
 try:
     from collections import OrderedDict
 except ImportError:
@@ -27,7 +28,7 @@ def construct_tree(index):
     :returns: tree of pkgs and their dependencies
     :rtype: dict
     """
-    return dict((p, [ReqPackage(r, index.get(r.key))
+    return dict((p, [ReqPackage(r, index.get(r.key) or index.get(canonicalize_package_name(r.key)))
                      for r in p.requires()])
                 for p in index.values())
 
@@ -68,3 +69,10 @@ def is_string(obj):
         return isinstance(obj, basestring)
     else:
         return isinstance(obj, str)
+
+
+def canonicalize_package_name(name):
+    # https://packaging.python.org/guides/distributing-packages-using-setuptools/#name
+    name = name.lower().replace('-', '.').replace('_', '.')
+    name = re.sub(r'\.+', '.', name)
+    return name


### PR DESCRIPTION
Hey there,

*How to reproduce a bug*
I found an interesting bug.
Let's assume that we have a package:
```
A
```

This package depends on package:
```
b.b
```
But we'll add it to deps as:
```
b_b
```
When we run snyk test on this project everything will be fine.

Now let's introduce a package:
```
C
```
This package depends on `A`

Finally when we run snyk test on this project snyk won't be able to find `b_b`.

*The root of the problem*
You don't normalize name of subpackages. You do it only for root level.

*Fix*
I copied fix from this part of your sources:
```
https://github.com/snyk/snyk-python-plugin/blob/master/pysrc/pip_resolve.py#L293-L297
```
