### PR TITLE
fix: support another kind of setuptools import

### DIFF
--- a/pysrc/setup_file.py
+++ b/pysrc/setup_file.py
@@ -10,7 +10,7 @@ def parse(setup_py_content):
 
     distutils.core.setup = _save_passed_args
     setuptools.setup = _save_passed_args
-    setup_py_content = setup_py_content.replace("setup(", "passed_arguments = setup(")
+    setup_py_content = re.sub(r"(setuptools\.)?setup\(", r"passed_arguments = \g<0>", setup_py_content)
 
     # Fetch the arguments that were passed to the setup.py
     exec(setup_py_content, globals())

--- a/test/unit/setup_file.spec.ts
+++ b/test/unit/setup_file.spec.ts
@@ -1,0 +1,18 @@
+import path = require('path');
+import { executeSync } from '../../lib/dependencies/sub-process';
+
+describe('Test setup_file.py', () => {
+  it.each`
+    setupPyContent
+    ${'import setuptools;setuptools.setup(name="test")'}
+    ${'from setuptools import setup;setup(name="test")'}
+  `("parse works for '$setupPyContent'", ({ setupPyContent }) => {
+    const result = executeSync(
+      'python',
+      ['-c', `from setup_file import parse; parse('${setupPyContent}')`],
+      { cwd: path.resolve(__dirname, '../../pysrc') }
+    );
+
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
today we only support "from setuptools import setup; setup(...)", this change adds support for "import setuptools; setuptools.setup(...)"
