### PR TITLE
fix: using node LTS for docker executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 defaults: &defaults
   resource_class: medium
   docker:
-    - image: cimg/node:19.6.1
+    - image: node:18
 
 jobs:
   lint:
@@ -54,8 +54,6 @@ jobs:
 
   release:
     <<: *defaults
-    docker:
-      - image: node:18
     steps:
       - checkout
       - node/install-packages:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 defaults: &defaults
   resource_class: medium
   docker:
-    - image: node:18
+    - image: cimg/node:18.17
 
 jobs:
   lint:


### PR DESCRIPTION
The previous configuration was using non-LTS versions of Node for the executors.