### PR TITLE
fix: package missing error

### DIFF
--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -47,7 +47,7 @@ def create_tree_of_packages_dependencies(
 
     tree = utils.sorted_tree(dist_tree)
     nodes = tree.keys()
-    key_tree = dict((k.key, v) for k, v in tree.items())
+    key_tree = dict((canonicalize_package_name(k.key), v) for k, v in tree.items())
 
     lowercase_pkgs_names = [p.name.lower() for p in top_level_requirements]
     tlr_by_key = dict((tlr.name.lower(), tlr) for tlr in top_level_requirements)
@@ -57,7 +57,8 @@ def create_tree_of_packages_dependencies(
             (p.project_name and p.project_name.lower()) in lowercase_pkgs_names]
 
     def create_children_recursive(root_package, key_tree, ancestors, all_packages_map):
-        root_name = root_package[NAME].lower()
+        root_name = canonicalize_package_name(root_package[NAME])
+
         if root_name not in key_tree:
             msg = 'Required packages missing: ' + root_name
             if allow_missing:

--- a/test/system/inspect.spec.ts
+++ b/test/system/inspect.spec.ts
@@ -117,7 +117,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 'markupsafe',
-              version: '2.1.3',
+              version: '2.1.4',
             },
             directDeps: ['jinja2'],
           },
@@ -131,7 +131,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 'markupsafe',
-              version: '2.1.3',
+              version: '2.1.4',
             },
             directDeps: ['jinja2'],
           },
@@ -159,7 +159,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 's3transfer',
-              version: '0.9.0',
+              version: '0.10.0',
             },
             directDeps: ['awss'],
           },
@@ -173,7 +173,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 'markupsafe',
-              version: '2.1.3',
+              version: '2.1.4',
             },
             directDeps: ['jinja2'],
           },
@@ -201,7 +201,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 'jsonschema',
-              version: '4.20.0',
+              version: '4.21.1',
             },
             directDeps: ['openapi-spec-validator'],
           },
@@ -232,6 +232,27 @@ describe('inspect', () => {
               version: '1.0.0',
             },
             directDeps: ['posix-ipc'],
+          },
+        ],
+      },
+      {
+        workspace: 'pip-app-deps-canonicalization',
+        uninstallPackages: [],
+        pluginOpts: {},
+        expected: [
+          {
+            pkg: {
+              name: 'zope.interface',
+              version: '5.4.0',
+            },
+            directDeps: ['zope.interface'],
+          },
+          {
+            pkg: {
+              name: 'twisted',
+              version: '23.10.0',
+            },
+            directDeps: ['twisted'],
           },
         ],
       },
@@ -381,7 +402,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 'markupsafe',
-              version: '2.1.3',
+              version: '2.1.4',
             },
             directDeps: ['jinja2'],
           },

--- a/test/workspaces/pip-app-deps-canonicalization/requirements.txt
+++ b/test/workspaces/pip-app-deps-canonicalization/requirements.txt
@@ -1,0 +1,2 @@
+zope.interface==5.4.0
+twisted==23.10.0


### PR DESCRIPTION
#### What does this PR do?
A bunch of projects were failing with `Required packages missing: <package_name>`. This was happening due to some symbol `-`, `_`, `.` miss-matching in the package names. The solution is to canonicalize the package names before comparing them. 
