### PR TITLE
fix: python circular deps / recursion error

### DIFF
--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -59,6 +59,11 @@ def create_tree_of_packages_dependencies(
     def create_children_recursive(root_package, key_tree, ancestors, all_packages_map):
         root_name = canonicalize_package_name(root_package[NAME])
 
+        # Checks if there is a circular dependency within the packages.
+        # Circular package example: apache.airflow and
+        if root_name in ancestors:
+            return root_package
+
         if root_name not in key_tree:
             msg = 'Required packages missing: ' + root_name
             if allow_missing:
@@ -70,8 +75,10 @@ def create_tree_of_packages_dependencies(
         ancestors = ancestors.copy()
         ancestors.add(root_name)
         children_packages_as_dist = key_tree[root_name]
+
         for child_dist in children_packages_as_dist:
             child_project_name = child_dist.project_name.lower()
+
             if child_project_name in ancestors:
                 continue
 

--- a/test/system/inspect.spec.ts
+++ b/test/system/inspect.spec.ts
@@ -117,7 +117,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 'markupsafe',
-              version: '2.1.4',
+              version: '2.1.5',
             },
             directDeps: ['jinja2'],
           },
@@ -131,7 +131,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 'markupsafe',
-              version: '2.1.4',
+              version: '2.1.5',
             },
             directDeps: ['jinja2'],
           },
@@ -173,7 +173,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 'markupsafe',
-              version: '2.1.4',
+              version: '2.1.5',
             },
             directDeps: ['jinja2'],
           },
@@ -286,6 +286,46 @@ describe('inspect', () => {
       await expect(
         async () => await inspect('.', FILENAMES.pip.manifest)
       ).rejects.toThrow('Required packages missing: markupsafe');
+    });
+  });
+
+  describe('Circular deps', () => {
+    let tearDown;
+    afterEach(() => {
+      tearDown();
+    });
+
+    it('Should get a valid dependency graph for circular dependencies', async () => {
+      const test_case = {
+        workspace: 'pip-app-circular-deps',
+        uninstallPackages: [],
+        pluginOpts: { allowEmpty: true }, // For Python 3.12
+        expected: [
+          {
+            pkg: {
+              name: 'apache-airflow',
+              version: '2.8.1',
+            },
+            directDeps: ['apache-airflow'],
+          },
+        ],
+      };
+      testUtils.chdirWorkspaces(test_case.workspace);
+      testUtils.ensureVirtualenv(test_case.workspace);
+      tearDown = testUtils.activateVirtualenv(test_case.workspace);
+      testUtils.pipInstall();
+      if (test_case.uninstallPackages) {
+        test_case.uninstallPackages.forEach((pkg) => {
+          testUtils.pipUninstall(pkg);
+        });
+      }
+
+      const result = await inspect(
+        '.',
+        FILENAMES.pip.manifest,
+        test_case.pluginOpts
+      );
+      expect(result).toHaveProperty('dependencyGraph');
     });
   });
 
@@ -402,7 +442,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 'markupsafe',
-              version: '2.1.4',
+              version: '2.1.5',
             },
             directDeps: ['jinja2'],
           },

--- a/test/workspaces/pip-app-circular-deps/requirements.txt
+++ b/test/workspaces/pip-app-circular-deps/requirements.txt
@@ -1,0 +1,1 @@
+apache-airflow==2.8.1; python_version<"3.12"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Some python packages, have circular dependencies. For example `apache-airflow` requires `apache-airflow-providers-common-io` which requires `apache-airflow`. This behaviour results in a recursion error:  
**RecursionError: maximum recursion depth exceeded while calling a Python object.**

This fix makes sure that if a dependency was already analysed, it won't get analysed again, thus avoiding the recursion error


#### Any background context you want to provide?
This bug was introduced after fixing another [issue](https://github.com/snyk/snyk-python-plugin/pull/231)


#### What are the relevant tickets?
[Slack conversation](https://snyk.slack.com/archives/CFTAUCYQ7/p1706869951896279)


#### Screenshots
<img width="1788" alt="Screenshot 2024-02-05 at 13 23 08" src="https://github.com/snyk/snyk-python-plugin/assets/150140904/39170fb5-319d-434e-a51b-9da0d774058d">