### PR TITLE
fix: added partial support for arbitrary identifiers

### DIFF
--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -260,8 +260,11 @@ def get_requirements_list(requirements_file_path, dev_deps=False):
     req_list = filter(is_testable, req_list)
     req_list = filter(matches_python_version, req_list)
     req_list = [r for r in req_list if r.name]
+
     for req in req_list:
-        req.name = req.name.lower().replace('_', '-')
+        req.name = utils.remove_arbitrary_identifiers(req.name)
+        req.name = req.name = req.name.lower().replace('_', '-')
+
     return req_list
 
 

--- a/pysrc/utils.py
+++ b/pysrc/utils.py
@@ -1,3 +1,4 @@
+import re
 from importlib import import_module
 from operator import attrgetter
 try:
@@ -68,3 +69,17 @@ def is_string(obj):
         return isinstance(obj, basestring)
     else:
         return isinstance(obj, str)
+
+
+def remove_arbitrary_identifiers(package_name: str) -> str:
+    """Removes arbitrary identifiers from package name
+
+    :param str package_name: package name to be processed
+    :returns: package_name without arbitrary identifiers
+    :rtype: string
+
+    opentelemetry-distro[otlp] -> opentelemetry-distro
+    """
+    package_name = re.sub(r'\[[^]]*]$', '', package_name)
+
+    return package_name

--- a/test/system/inspect.spec.ts
+++ b/test/system/inspect.spec.ts
@@ -416,6 +416,9 @@ describe('inspect', () => {
 
     it.each([
       {
+        workspace: 'pipfile-arbitrary-identifiers',
+      },
+      {
         workspace: 'pipfile-pipapp-pinned',
       },
       {

--- a/test/workspaces/pip-app/requirements.txt
+++ b/test/workspaces/pip-app/requirements.txt
@@ -7,3 +7,4 @@ irc==16.2 # this has a cyclic dependency (internal jaraco.text <==> jaraco.colle
 testtools==\
     2.3.0 # this has a cycle (fixtures ==> testtools);
 ./packages/prometheus_client-0.6.0
+opentelemetry-distro[otlp] == 0.35b0

--- a/test/workspaces/pipfile-arbitrary-identifiers/Pipfile
+++ b/test/workspaces/pipfile-arbitrary-identifiers/Pipfile
@@ -1,0 +1,14 @@
+[requires]
+python_version = "3.11.6"
+
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+'opentelemetry-distro[otlp]' = '==0.35b0'
+"Jinja2" = { version = "*" }
+
+[pipenv]
+allow_prereleases = true


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Ads partial support for arbitrary identifiers, partial because the actual implementation would take quite a lot of time to implement and would require some refactoring of the pysrc code. 
These changes make sure that in case some of our clients use arbitrary identifiers, the graph creation won't break (as it did until now).

### WARNING
Until we will fully support this way of declaring dependencies, the deps that are being added by arbitrary identifiers won't show up in the graph that is being created.


#### What are the relevant tickets?
[SUP-2224](https://snyksec.atlassian.net/browse/SUP-2224)



[SUP-2224]: https://snyksec.atlassian.net/browse/SUP-2224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ