### PR TITLE
fix: add support for dev/alpha/beta/rc python versions

### DIFF
--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -135,25 +135,47 @@ def create_tree_of_packages_dependencies(
             dir_as_root[DEPENDENCIES][package_as_root[NAME]] = package_tree
     return dir_as_root
 
-def satisfies_python_requirement(parsed_operator, py_version_str):
+
+def satisfies_python_requirement(parsed_operator, py_version):
+    """Check if a package required python versions matches the one of the system
+
+    Args:
+        parsed_operator (str): operator to compare by i.e. >, <=, ==
+        py_version (str): The python version that is required by the package
+
+    Returns:
+        bool: True if the version matches, False otherwise
+    """
     # TODO: use python semver library to compare versions
-    operator_func = {
+    operator = {
         ">": gt,
         "==": eq,
         "<": lt,
         "<=": le,
         ">=": ge,
         '!=': ne,
-    }[parsed_operator]
+    }
+    operator_func = operator.get(parsed_operator)
     system_py_version_tuple = (sys.version_info[0], sys.version_info[1])
-    py_version_tuple = tuple(py_version_str.split('.')) # string tuple
+    py_version_tuple = tuple(py_version.split('.'))  # tuple of strings
+
+    # For wildcard versions like 3.9.*
     if py_version_tuple[-1] == '*':
         system_py_version_tuple = system_py_version_tuple[0]
-        py_version_tuple = int(py_version_tuple[0]) # int tuple
-    else:
-        py_version_tuple = tuple(int(x) for x in py_version_tuple) # int tuple
+        py_version_tuple = int(py_version_tuple[0])  # tuple of integers
 
-    return operator_func(system_py_version_tuple, py_version_tuple)
+    # For dev/alpha/beta/rc versions like 3.9.dev0
+    elif not py_version_tuple[-1].isdigit():
+        py_version_tuple = (int(py_version_tuple[0]), int(py_version_tuple[1]))
+
+    # For stable releases like 3.9.2
+    else:
+        py_version_tuple = tuple(int(x) for x in py_version_tuple)
+
+    result = operator_func(system_py_version_tuple, py_version_tuple)
+
+    return result
+
 
 def get_markers_text(requirement):
     if isinstance(requirement, pipfile.PipfileRequirement):

--- a/test/system/inspect.spec.ts
+++ b/test/system/inspect.spec.ts
@@ -256,6 +256,20 @@ describe('inspect', () => {
           },
         ],
       },
+      {
+        workspace: 'pip-app-dev-alpha-beta-python-version',
+        uninstallPackages: [],
+        pluginOpts: {},
+        expected: [
+          {
+            pkg: {
+              name: 'requests',
+              version: '2.31.0',
+            },
+            directDeps: ['requests'],
+          },
+        ],
+      },
     ])(
       'should get a valid dependency graph for workspace = $workspace',
       async ({ workspace, uninstallPackages, pluginOpts, expected }) => {

--- a/test/workspaces/pip-app-dev-alpha-beta-python-version/requirements.txt
+++ b/test/workspaces/pip-app-dev-alpha-beta-python-version/requirements.txt
@@ -1,0 +1,1 @@
+requests==2.31.0 ; python_version >= "3.8.dev0"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Adds support for development, alpha, beta and release candidate python versions.

Now we will support the following python versions:
- Stable release versions: `3.9.2`
- Wildcard versions: `3.9.*`
- Development versions: `3.9.dev0`
- Alpha release versions: `3.9.a1`
- Beta release versions: `3.9.b2`
- Release candidate versions: `3.9.rc01`


#### What are the relevant tickets?
[Support ticket SUP-2503](https://snyksec.atlassian.net/browse/SUP-2503)