### PR TITLE
fix: invalid escape sequence in python 3.12

### DIFF
--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -231,7 +231,7 @@ def matches_python_version(requirement):
 
     # Gloss over the 'and' case and return true on the first matching python version
 
-    for sub_exp in re.split("\s*(?:and|or)\s*", cond_text):
+    for sub_exp in re.split(r"\s*(?:and|or)\s*", cond_text):
         match = PYTHON_MARKER_REGEX.search(sub_exp)
 
         if match:


### PR DESCRIPTION
Changes the regular expression string to be a raw string

> A backslash-character pair that is not a valid escape sequence now
> generates a SyntaxWarning, instead of DeprecationWarning. For example,
> re.compile("\d+\.\d+") now emits a SyntaxWarning ("\d" is an invalid
> escape sequence, use raw strings for regular expression:
> re.compile(r"\d+\.\d+")). In a future Python version, SyntaxError will
> eventually be raised, instead of SyntaxWarning. (Contributed by Victor
> Stinner in gh-98401.)

https://docs.python.org/3/whatsnew/3.12.html#other-language-changes

- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes an invalid escape sequence in 3.12

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

When running Snyk CLI on a Python 3.12 pipenv project the following execeptions are raised

```
[SNYK STDERR] 2024-05-31T04:34:21.396Z snyk:run-test Error running test {
[SNYK STDERR]   error: "/tmp/tmp-536-T2NfRrvF0nOq/pip_resolve.py:234: SyntaxWarning: invalid escape sequence '\\s'\n" +
[SNYK STDERR]     '  for sub_exp in re.split("\\s*(?:and|or)\\s*", cond_text):\n' +
[SNYK STDERR]     "/tmp/tmp-536-T2NfRrvF0nOq/pip_resolve.py:234: SyntaxWarning: invalid escape sequence '\\s'\n" +
[SNYK STDERR]     '  for sub_exp in re.split("\\s*(?:and|or)\\s*", cond_text):\n' +
[SNYK STDERR]     'Traceback (most recent call last):\n' +
[SNYK STDERR]     '  File "/tmp/tmp-536-T2NfRrvF0nOq/pip_resolve.py", line 7, in <module>\n' +
[SNYK STDERR]     '    import utils\n' +
[SNYK STDERR]     '  File "/tmp/tmp-536-T2NfRrvF0nOq/utils.py", line 3, in <module>\n' +
[SNYK STDERR]     '    import pip_resolve\n' +
[SNYK STDERR]     '  File "/tmp/tmp-536-T2NfRrvF0nOq/pip_resolve.py", line 10, in <module>\n' +
[SNYK STDERR]     '    import setup_file\n' +
[SNYK STDERR]     '  File "/tmp/tmp-536-T2NfRrvF0nOq/setup_file.py", line 1, in <module>\n' +
[SNYK STDERR]     '    import distutils.core\n' +
[SNYK STDERR]     "ModuleNotFoundError: No module named 'distutils'\n"
[SNYK STDERR] }
```

This fixes the first exception regarding the invalid escape sequence

#### What are the relevant tickets?


#### Screenshots


#### Additional questions
