### PR TITLE
fix: solve setup tools not installed on 3.12 python versions

### DIFF
--- a/lib/dependencies/index.ts
+++ b/lib/dependencies/index.ts
@@ -27,6 +27,7 @@ export async function getDependencies(
     options = {};
   }
   let command = options.command || 'python';
+  const initialCommand = command;
   const includeDevDeps = !!(options.dev || false);
 
   // handle poetry projects by parsing manifest & lockfile and return a dep-graph
@@ -57,8 +58,10 @@ export async function getDependencies(
       options.allowMissing || false,
       includeDevDeps,
       options.allowEmpty,
+      initialCommand,
       options.args,
-      options.projectName
+      options.projectName,
+      
     ),
   ]);
   return { plugin, dependencyGraph };

--- a/lib/dependencies/index.ts
+++ b/lib/dependencies/index.ts
@@ -60,8 +60,7 @@ export async function getDependencies(
       options.allowEmpty,
       initialCommand,
       options.args,
-      options.projectName,
-      
+      options.projectName
     ),
   ]);
   return { plugin, dependencyGraph };

--- a/lib/dependencies/inspect-implementation.ts
+++ b/lib/dependencies/inspect-implementation.ts
@@ -246,6 +246,7 @@ export async function inspectInstalledDeps(
   allowMissing: boolean,
   includeDevDeps: boolean,
   allowEmpty: boolean,
+  initialCommand = 'python',
   args?: string[],
   projectName?: string
 ): Promise<DepGraph> {
@@ -261,7 +262,7 @@ export async function inspectInstalledDeps(
       UPDATED_SETUPTOOLS_VERSION,
       root,
       pythonEnv,
-      command
+      initialCommand
     );
 
     // See ../../pysrc/README.md

--- a/test/system/inspect.spec.ts
+++ b/test/system/inspect.spec.ts
@@ -100,7 +100,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 'jaraco.collections',
-              version: '5.0.0',
+              version: '5.0.1',
             },
             directDeps: ['irc'],
           },
@@ -163,7 +163,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 's3transfer',
-              version: '0.10.0',
+              version: '0.10.2',
             },
             directDeps: ['awss'],
           },
@@ -205,7 +205,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 'jsonschema',
-              version: '4.21.1',
+              version: '4.23.0',
             },
             directDeps: ['openapi-spec-validator'],
           },


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

####What this PR do? 
Fix to [T3S-84](https://snyksec.atlassian.net/browse/T3S-84) issue , based on support ticket [81735](https://snyk.zendesk.com/agent/tickets/81735) , basically setup tools were not installed since that **updateSetuptools** procedure was getting the wrong values.
Setup tools were deprecated since Python 3.12 version , for this scenario special procedure was created , however it has an issue which this PR solving.


####What files were affected?
Index.ts 
inspect-implementations.ts
test/system/inspect.spec.ts - fixed values to enable circle-ci


####Relevant Support Tickets? 
[Jira T3S-84](https://snyksec.atlassian.net/browse/T3S-84) - [Zendesk 81735](https://snyk.zendesk.com/agent/tickets/81735) 
[Jira T3S-98](https://snyksec.atlassian.net/browse/T3S-98) - [Zendesk 85170](https://snyk.zendesk.com/agent/tickets/85170)




[T3S-84]: https://snyksec.atlassian.net/browse/T3S-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ