### PR TITLE
fix: correct cmd to get python version for pipenv projects

### DIFF
--- a/lib/dependencies/index.ts
+++ b/lib/dependencies/index.ts
@@ -27,6 +27,7 @@ export async function getDependencies(
     options = {};
   }
   let command = options.command || 'python';
+  const pythonCmd = command;
   const includeDevDeps = !!(options.dev || false);
 
   // handle poetry projects by parsing manifest & lockfile and return a dep-graph
@@ -51,6 +52,7 @@ export async function getDependencies(
     getMetaData(command, baseargs, root, targetFile),
     inspectInstalledDeps(
       command,
+      pythonCmd,
       baseargs,
       root,
       targetFile,

--- a/lib/dependencies/inspect-implementation.ts
+++ b/lib/dependencies/inspect-implementation.ts
@@ -240,6 +240,7 @@ async function updateSetuptools(
 
 export async function inspectInstalledDeps(
   command: string,
+  pythonCmd: string,
   baseargs: string[],
   root: string,
   targetFile: string,
@@ -261,7 +262,7 @@ export async function inspectInstalledDeps(
       UPDATED_SETUPTOOLS_VERSION,
       root,
       pythonEnv,
-      command
+      pythonCmd
     );
 
     // See ../../pysrc/README.md

--- a/test/system/inspect.spec.ts
+++ b/test/system/inspect.spec.ts
@@ -100,7 +100,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 'jaraco.collections',
-              version: '5.0.0',
+              version: '5.0.1',
             },
             directDeps: ['irc'],
           },
@@ -163,7 +163,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 's3transfer',
-              version: '0.10.0',
+              version: '0.10.2',
             },
             directDeps: ['awss'],
           },
@@ -205,7 +205,7 @@ describe('inspect', () => {
           {
             pkg: {
               name: 'jsonschema',
-              version: '4.21.1',
+              version: '4.23.0',
             },
             directDeps: ['openapi-spec-validator'],
           },
@@ -449,6 +449,49 @@ describe('inspect', () => {
       const expectedTargetFile = `${dirname}/Pipfile`;
       expect(result.plugin.targetFile).toEqual(expectedTargetFile);
     });
+  });
+
+  describe('when testing pipenv projects simulating pipenv install', () => {
+    let tearDown;
+
+    afterAll(() => {
+      tearDown();
+    });
+
+    it.each([
+      {
+        workspace: 'pipfile-pipapp-pinned',
+        targetFile: undefined,
+      },
+      {
+        workspace: 'pipenv-app',
+        targetFile: undefined,
+      },
+    ])(
+      'should get a valid dependency graph for workspace = $workspace',
+      async ({ workspace, targetFile }) => {
+        testUtils.chdirWorkspaces(workspace);
+        testUtils.ensureVirtualenv(workspace);
+        tearDown = testUtils.activateVirtualenv(workspace);
+        testUtils.pipenvInstall();
+        testUtils.chdirWorkspaces(workspace);
+        const result = await inspect(
+          '.',
+          targetFile ? targetFile : FILENAMES.pipenv.manifest
+        );
+
+        const expected = [
+          {
+            pkg: {
+              name: 'markupsafe',
+              version: '2.1.5',
+            },
+            directDeps: ['jinja2'],
+          },
+        ];
+        compareTransitiveLines(result.dependencyGraph, expected);
+      }
+    );
   });
 
   describe('when generating Pipfile depGraphs ', () => {

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -10,6 +10,7 @@ export {
   deactivateVirtualenv,
   ensureVirtualenv,
   pipInstall,
+  pipenvInstall,
   pipUninstall,
   setupPyInstall,
 };
@@ -135,6 +136,19 @@ function pipInstall() {
     console.log('' + proc.stderr);
     throw new Error(
       'Failed to install requirements with pip.' +
+        ' venv = ' +
+        JSON.stringify(getActiveVenvName())
+    );
+  }
+}
+
+function pipenvInstall() {
+  const proc = subProcess.executeSync('pipenv', ['install']);
+
+  if (proc.status !== 0) {
+    console.log('' + proc.stderr);
+    throw new Error(
+      'Failed to install requirements with pipenv.' +
         ' venv = ' +
         JSON.stringify(getActiveVenvName())
     );


### PR DESCRIPTION
#### What does this PR do?

After https://github.com/snyk/snyk-python-plugin/pull/242.
Fixed command to check python version. For pipenv projects, it changes to `pipenv`, but we need the initial `python` or `python3` to check python version with `--version`.
Python version is checked because setuptools need to be installed in case of python 3.12.

Added tests to simulate pipenv virtualenv, where pipenv install is performed and then inspect called.
