### PR TITLE
fix: [OSM-2206] skip unresolved local packages

### DIFF
--- a/lib/dependencies/inspect-implementation.ts
+++ b/lib/dependencies/inspect-implementation.ts
@@ -6,7 +6,11 @@ import * as subProcess from './sub-process';
 import { DepGraph } from '@snyk/dep-graph';
 import { buildDepGraph, PartialDepTree } from './build-dep-graph';
 import { FILENAMES } from '../types';
-import { EmptyManifestError, RequiredPackagesMissingError } from '../errors';
+import {
+  EmptyManifestError,
+  RequiredPackagesMissingError,
+  UnparsableRequirementError,
+} from '../errors';
 
 const returnedTargetFile = (originalTargetFile) => {
   const basename = path.basename(originalTargetFile);
@@ -270,6 +274,10 @@ export async function inspectInstalledDeps(
         errMsg += ' If the issue persists try again with --skip-unresolved.';
 
         throw new RequiredPackagesMissingError(errMsg);
+      }
+
+      if (error.indexOf('Unparsable requirement line') !== -1) {
+        throw new UnparsableRequirementError(error);
       }
     }
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,6 +1,7 @@
 export enum PythonPluginErrorNames {
   EMPTY_MANIFEST_ERROR = 'EMPTY_MANIFEST_ERROR',
   REQUIRED_PACKAGES_MISSING_ERROR = 'REQUIRED_PACKAGES_MISSING_ERROR',
+  UNPARSABLE_REQUIREMENT_ERROR = 'UNPARSABLE_REQUIREMENT_ERROR',
 }
 
 export class EmptyManifestError extends Error {
@@ -14,5 +15,12 @@ export class RequiredPackagesMissingError extends Error {
   constructor(message: string) {
     super(message);
     this.name = PythonPluginErrorNames.REQUIRED_PACKAGES_MISSING_ERROR;
+  }
+}
+
+export class UnparsableRequirementError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = PythonPluginErrorNames.UNPARSABLE_REQUIREMENT_ERROR;
   }
 }

--- a/pysrc/constants.py
+++ b/pysrc/constants.py
@@ -23,3 +23,10 @@ class DepsManager:
             return cls.SETUPTOOLS
 
         return cls.PIP
+
+DEFAULT_OPTIONS = {
+    "allow_missing":False,
+    "dev_deps":False,
+    "only_provenance":False,
+    "allow_empty":False
+}

--- a/test/system/inspect.spec.ts
+++ b/test/system/inspect.spec.ts
@@ -740,6 +740,31 @@ describe('inspect', () => {
         async () => await inspect('.', FILENAMES.pip.manifest)
       ).rejects.toThrow('Required packages missing: markupsafe');
     });
+
+    it('should fail on nonexistent referenced local depedency', async () => {
+      const workspace = 'pip-app-local-nonexistent-file';
+      testUtils.chdirWorkspaces(workspace);
+      testUtils.ensureVirtualenv(workspace);
+      tearDown = testUtils.activateVirtualenv(workspace);
+
+      await expect(inspect('.', FILENAMES.pip.manifest)).rejects.toThrow(
+        "Unparsable requirement line ([Errno 2] No such file or directory: './lib/nonexistent/setup.py')"
+      );
+    });
+
+    it('should not fail on nonexistent referenced local depedency when --skip-unresolved', async () => {
+      const workspace = 'pip-app-local-nonexistent-file';
+      testUtils.chdirWorkspaces(workspace);
+      testUtils.ensureVirtualenv(workspace);
+      tearDown = testUtils.activateVirtualenv(workspace);
+
+      const result = await inspect('.', FILENAMES.pip.manifest, {
+        allowMissing: true,
+        allowEmpty: true,
+      });
+
+      expect(result.dependencyGraph.toJSON()).not.toEqual({});
+    });
   });
 
   describe('Circular deps', () => {

--- a/test/workspaces/pip-app-local-nonexistent-file/lib/nonexistent/not-setup-file.txt
+++ b/test/workspaces/pip-app-local-nonexistent-file/lib/nonexistent/not-setup-file.txt
@@ -1,0 +1,1 @@
+This is a dummy file

--- a/test/workspaces/pip-app-local-nonexistent-file/requirements.txt
+++ b/test/workspaces/pip-app-local-nonexistent-file/requirements.txt
@@ -1,0 +1,1 @@
+./lib/nonexistent


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Handles errors for a requirement line that can't be parsed.
If --skip-unresolved (allowMissing) is true, the lines that throw errors are ignored.
