### PR TITLE
fix: [OSM-2189] refactor sys_platform selector

### DIFF
--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -16,7 +16,7 @@ import pkg_resources
 PYTHON_MARKER_REGEX = re.compile(r'python_version\s*('
                                  r'?P<operator>==|<=|>=|>|<)\s*[\'"]('
                                  r'?P<python_version>.+?)[\'"]')
-SYSTEM_MARKER_REGEX = re.compile(r'sys_platform\s*==\s*[\'"]([^\'"]+)[\'"]$')
+SYSTEM_MARKER_REGEX = re.compile(r'sys_platform\s*==\s*[\'"]([\w.-]+)[\'"]')
 DEPENDENCIES = 'dependencies'
 VERSION = 'version'
 NAME = 'name'
@@ -271,9 +271,10 @@ def matches_environment(requirement):
     sys_platform = sys.platform.lower()
     markers_text = get_markers_text(requirement)
     if markers_text and 'sys_platform' in markers_text:
-        match = SYSTEM_MARKER_REGEX.findall(markers_text)
-        if len(match) > 0:
-            return match[0].lower() == sys_platform
+        matches = SYSTEM_MARKER_REGEX.findall(markers_text)
+        lowercase_matches = [match.lower() for match in matches]
+        if len(lowercase_matches) > 0:
+            return sys_platform.lower() in lowercase_matches
     return True
 
 

--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -273,7 +273,7 @@ def matches_environment(requirement):
     if markers_text and 'sys_platform' in markers_text:
         matches = SYSTEM_MARKER_REGEX.findall(markers_text)
         lowercase_matches = [match.lower() for match in matches]
-        if len(lowercase_matches) > 0:
+        if lowercase_matches:
             return sys_platform.lower() in lowercase_matches
     return True
 

--- a/pysrc/pip_resolve.py
+++ b/pysrc/pip_resolve.py
@@ -16,7 +16,7 @@ import pkg_resources
 PYTHON_MARKER_REGEX = re.compile(r'python_version\s*('
                                  r'?P<operator>==|<=|>=|>|<)\s*[\'"]('
                                  r'?P<python_version>.+?)[\'"]')
-SYSTEM_MARKER_REGEX = re.compile(r'sys_platform\s*==\s*[\'"](.+)[\'"]')
+SYSTEM_MARKER_REGEX = re.compile(r'sys_platform\s*==\s*[\'"]([^\'"]+)[\'"]$')
 DEPENDENCIES = 'dependencies'
 VERSION = 'version'
 NAME = 'name'

--- a/pysrc/test_pip_resolve_py3.py
+++ b/pysrc/test_pip_resolve_py3.py
@@ -58,6 +58,10 @@ class TestStringMethods(unittest.TestCase):
             req.line = "futures==3.2.0; sys_platform == 'linux2'"
             self.assertFalse    (matches_environment(req))
 
+            mock_sys.platform = "linux"
+            req.line = "jinja2==3.1.4 ; sys_platform == 'darwin' or sys_platform == 'linux'"
+            self.assertTrue(matches_environment(req))
+
             # BUG: Only == operator is supported in the moment
             # mock_sys.platform = "linux2"
             # req.line = "futures==3.2.0; sys_platform != 'linux2'"

--- a/pysrc/test_pip_resolve_py3.py
+++ b/pysrc/test_pip_resolve_py3.py
@@ -62,6 +62,10 @@ class TestStringMethods(unittest.TestCase):
             req.line = "jinja2==3.1.4 ; sys_platform == 'darwin' or sys_platform == 'linux'"
             self.assertTrue(matches_environment(req))
 
+            mock_sys.platform = "darwin"
+            req.line = "jinja2==3.1.4 ; sys_platform == 'darwin' or sys_platform == 'linux'"
+            self.assertTrue(matches_environment(req))
+
             # BUG: Only == operator is supported in the moment
             # mock_sys.platform = "linux2"
             # req.line = "futures==3.2.0; sys_platform != 'linux2'"


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
- Refactors regex used to select the `sys_platform`
- Improved logic to support multiple `sys_platform`

#### Where should the reviewer start?
#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
