### PR TITLE
fix: fix test to not check version of package

### DIFF
--- a/test/system/inspect.spec.ts
+++ b/test/system/inspect.spec.ts
@@ -211,7 +211,6 @@ describe('inspect', () => {
           {
             pkg: {
               name: 's3transfer',
-              version: '0.10.4',
             },
             directDeps: ['awss'],
           },
@@ -584,7 +583,6 @@ describe('inspect', () => {
           {
             pkg: {
               name: 's3transfer',
-              version: '0.10.4',
             },
             directDeps: ['awss'],
           },


### PR DESCRIPTION
#### What does this PR do?

Removed checked version of package in test because the latest version is always pulled in.
Because of this, should a newer version of a package be published, we would need to update the tests.
Therefore, let's just check that the package exists in the dependency graph.
Also see https://github.com/snyk/snyk-python-plugin/pull/253
