### PR TITLE
chore: remove checked dependency version from unit test

### DIFF
--- a/test/system/inspect.spec.ts
+++ b/test/system/inspect.spec.ts
@@ -157,7 +157,6 @@ describe('inspect', () => {
           {
             pkg: {
               name: 'django-appconf',
-              version: '1.0.6',
             },
             directDeps: ['django-select2'],
           },
@@ -529,7 +528,6 @@ describe('inspect', () => {
           {
             pkg: {
               name: 'django-appconf',
-              version: '1.0.6',
             },
             directDeps: ['django-select2'],
           },


### PR DESCRIPTION
Remove checked version for sub-dependency in unit tests because newer python versiones bring in the sub-dependency with a later version. For this specific test, we are not concerned with what version the sub-dependency gets pinned at.