### PR TITLE
fix: incorrect package name normalisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ venv/
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 .DS_Store
+
+test/workspaces/**/build/

--- a/pysrc/pkg_resources_py3/__init__.py
+++ b/pysrc/pkg_resources_py3/__init__.py
@@ -3024,6 +3024,30 @@ class DistInfoDistribution(Distribution):
             metadata = self.get_metadata(self.PKG_INFO)
             self._pkg_info = email.parser.Parser().parsestr(metadata)
             return self._pkg_info
+    
+    def _reload_version(self):
+        """
+        Reload version and project_name from METADATA file.
+        
+        For .dist-info directories, the directory name may use underscores
+        (e.g., zope_event-6.1.dist-info) even though the actual package name
+        uses dots (e.g., zope.event). We need to read the correct Name from
+        the METADATA file to avoid mismatches.
+        """
+        md_version = self._get_version()
+        if md_version:
+            self._version = md_version
+        
+        # Read the Name field from METADATA
+        try:
+            md_name = self._parsed_pkg_info.get('Name')
+            if md_name:
+                self.project_name = safe_name(md_name.strip())
+        except Exception:
+            # If we can't read metadata, keep the name from directory parsing
+            pass
+        
+        return self
 
     @property
     def _dep_map(self):

--- a/pysrc/pkg_resources_py3_12/__init__.py
+++ b/pysrc/pkg_resources_py3_12/__init__.py
@@ -3102,6 +3102,30 @@ class DistInfoDistribution(Distribution):
             metadata = self.get_metadata(self.PKG_INFO)
             self._pkg_info = email.parser.Parser().parsestr(metadata)
             return self._pkg_info
+    
+    def _reload_version(self):
+        """
+        Reload version and project_name from METADATA file.
+        
+        For .dist-info directories, the directory name may use underscores
+        (e.g., zope_event-6.1.dist-info) even though the actual package name
+        uses dots (e.g., zope.event). We need to read the correct Name from
+        the METADATA file to avoid mismatches.
+        """
+        md_version = self._get_version()
+        if md_version:
+            self._version = md_version
+        
+        # Read the Name field from METADATA
+        try:
+            md_name = self._parsed_pkg_info.get('Name')
+            if md_name:
+                self.project_name = safe_name(md_name.strip())
+        except Exception:
+            # If we can't read metadata, keep the name from directory parsing
+            pass
+        
+        return self
 
     @property
     def _dep_map(self):

--- a/pysrc/reqPackage.py
+++ b/pysrc/reqPackage.py
@@ -15,6 +15,13 @@ class ReqPackage(Package):
     def __init__(self, obj, dist=None):
         super(ReqPackage, self).__init__(obj)
         self.dist = dist
+        
+        # Use the distribution's key and project_name if available,
+        # as the requirement string may use a different naming convention
+        # (e.g., requirement uses 'zope-interface' but package is 'zope.interface')
+        if dist:
+            self.key = dist.key
+            self.project_name = dist.project_name
 
     @property
     def version_spec(self):

--- a/test/system/inspect.spec.ts
+++ b/test/system/inspect.spec.ts
@@ -289,9 +289,9 @@ describe('inspect', () => {
         expected: [
           {
             pkg: {
-              name: 'zope-interface',
+              name: 'zope.interface',
             },
-            directDeps: ['twisted'],
+            directDeps: ['twisted', 'zope.interface'],
           },
           {
             pkg: {
@@ -670,9 +670,9 @@ describe('inspect', () => {
         expected: [
           {
             pkg: {
-              name: 'zope-interface',
+              name: 'zope.interface',
             },
-            directDeps: ['twisted'],
+            directDeps: ['twisted', 'zope.interface'],
           },
           {
             pkg: {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

- Read canonical package names from metadata files instead of parsing it from directory names.
- Use resolved package names in dependency tree when available, ensuring requirement strings (e.g., zope-interface) correctly map to installed packages (e.g., zope.interface).
- Update test expectations: Fixed pip-app-deps-canonicalization test to correctly expect both root and transitive dependency paths now that package names are properly normalized.

#### Any background context you want to provide?

Fixes an issue where packages with `.` characters in the name are incorrectly normalised to have `-` characters instead.

#### What are the relevant tickets?
[Jira ticket: OSM-3152](https://snyksec.atlassian.net/browse/OSM-3152)