### PR TITLE
🔒 Fix 2 security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@snyk/cli-interface": "^2.11.2",
-    "@snyk/dep-graph": "^1.28.1",
+    "@snyk/dep-graph": "^2.16.8",
     "@snyk/error-catalog-nodejs-public": "^5.77.0",
     "shescape": "2.1.6",
-    "snyk-poetry-lockfile-parser": "^1.9.1",
+    "snyk-poetry-lockfile-parser": "^1.9.2",
     "tmp": "0.2.3"
   },
   "devDependencies": {

--- a/test/workspaces/pipenv-app/Pipfile.lock
+++ b/test/workspaces/pipenv-app/Pipfile.lock
@@ -1,0 +1,188 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "6c4029e96e240f5c4614f27b2316155c6bcbf0e57b076db5bea451dda0866125"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "dnspython": {
+            "hashes": [
+                "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af",
+                "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==2.8.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
+                "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.6"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f",
+                "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a",
+                "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf",
+                "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19",
+                "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf",
+                "sha256:0f4b68347f8c5eab4a13419215bdfd7f8c9b19f2b25520968adfad23eb0ce60c",
+                "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175",
+                "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219",
+                "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb",
+                "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6",
+                "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab",
+                "sha256:15d939a21d546304880945ca1ecb8a039db6b4dc49b2c5a400387cdae6a62e26",
+                "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1",
+                "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce",
+                "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218",
+                "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634",
+                "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695",
+                "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad",
+                "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73",
+                "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c",
+                "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe",
+                "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa",
+                "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559",
+                "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa",
+                "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37",
+                "sha256:3537e01efc9d4dccdf77221fb1cb3b8e1a38d5428920e0657ce299b20324d758",
+                "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f",
+                "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8",
+                "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d",
+                "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c",
+                "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97",
+                "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a",
+                "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19",
+                "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9",
+                "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9",
+                "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc",
+                "sha256:591ae9f2a647529ca990bc681daebdd52c8791ff06c2bfa05b65163e28102ef2",
+                "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4",
+                "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354",
+                "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50",
+                "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698",
+                "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9",
+                "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b",
+                "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc",
+                "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115",
+                "sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e",
+                "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485",
+                "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f",
+                "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12",
+                "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025",
+                "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009",
+                "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d",
+                "sha256:949b8d66bc381ee8b007cd945914c721d9aba8e27f71959d750a46f7c282b20b",
+                "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a",
+                "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5",
+                "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f",
+                "sha256:a320721ab5a1aba0a233739394eb907f8c8da5c98c9181d1161e77a0c8e36f2d",
+                "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1",
+                "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287",
+                "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6",
+                "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f",
+                "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581",
+                "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed",
+                "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b",
+                "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c",
+                "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026",
+                "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8",
+                "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676",
+                "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6",
+                "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e",
+                "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d",
+                "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d",
+                "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01",
+                "sha256:df2449253ef108a379b8b5d6b43f4b1a8e81a061d6537becd5582fba5f9196d7",
+                "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419",
+                "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795",
+                "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1",
+                "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5",
+                "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d",
+                "sha256:e8fc20152abba6b83724d7ff268c249fa196d8259ff481f3b1476383f8f24e42",
+                "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe",
+                "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda",
+                "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e",
+                "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737",
+                "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523",
+                "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591",
+                "sha256:f71a396b3bf33ecaa1626c255855702aca4d3d9fea5e051b41ac59a9c1c41edc",
+                "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a",
+                "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==3.0.3"
+        },
+        "python-etcd": {
+            "hashes": [
+                "sha256:f1b5ebb825a3e8190494f5ce1509fde9069f2754838ed90402a8c11e1f52b8cb"
+            ],
+            "index": "pypi",
+            "version": "==0.4.5"
+        },
+        "testtools": {
+            "hashes": [
+                "sha256:39ad9eb9e1b935d6838f4b3aee4d6e72db65df5602f6feda998dbb4fe8de0b19",
+                "sha256:faf2d689b3614d87459f7f715fc8349a3f77a252486b104d0cfe635b44326895"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.9.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f",
+                "sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.26.16"
+        }
+    },
+    "develop": {
+        "beautifulsoup4": {
+            "hashes": [
+                "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb",
+                "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86"
+            ],
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==4.14.3"
+        },
+        "bs4": {
+            "hashes": [
+                "sha256:a48685c58f50fe127722417bae83fe6badf500d54b55f7e39ffe43b798653925",
+                "sha256:abf8742c0805ef7f662dce4b51cca104cffe52b835238afc169142ab9b3fbccc"
+            ],
+            "index": "pypi",
+            "version": "==0.0.2"
+        },
+        "soupsieve": {
+            "hashes": [
+                "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349",
+                "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.8.3"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+                "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==4.15.0"
+        }
+    }
+}

--- a/test/workspaces/pipfile-pipapp-pinned/Pipfile.lock
+++ b/test/workspaces/pipfile-pipapp-pinned/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bd1e9c623aaaa8657487c300cc7af3ef666c70fbd375aeeaf0f918db1428ab6b"
+            "sha256": "08d8c76c062b79aa9f0013264c70a17dc0d74484d8de1f41d4820ef794d0eebb"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,12 +14,28 @@
         ]
     },
     "default": {
+        "annotated-doc": {
+            "hashes": [
+                "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320",
+                "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.0.4"
+        },
         "argparse": {
             "hashes": [
                 "sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4",
                 "sha256:c31647edb69fd3d465a847ea3157d37bed1f95f19760b11a47aa91c04b666314"
             ],
             "version": "==1.4.0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2",
+                "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==8.3.3"
         },
         "django": {
             "hashes": [
@@ -31,10 +47,11 @@
         },
         "django-appconf": {
             "hashes": [
-                "sha256:6a4d9aea683b4c224d97ab8ee11ad2d29a37072c0c6c509896dd9857466fb261",
-                "sha256:ddab987d14b26731352c01ee69c090a4ebfc9141ed223bef039d79587f22acd9"
+                "sha256:15a88d60dd942d6059f467412fe4581db632ef03018a3c183fb415d6fc9e5cec",
+                "sha256:b81bce5ef0ceb9d84df48dfb623a32235d941c78cc5e45dbb6947f154ea277f4"
             ],
-            "version": "==1.0.2"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.2.0"
         },
         "django-select2": {
             "hashes": [
@@ -45,10 +62,11 @@
         },
         "dnspython": {
             "hashes": [
-                "sha256:40f563e1f7a7b80dc5a4e76ad75c23da53d62f1e15e6e517293b04e1f84ead7c",
-                "sha256:861e6e58faa730f9845aaaa9c6c832851fbf89382ac52915a51f89c71accdd31"
+                "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af",
+                "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f"
             ],
-            "version": "==1.15.0"
+            "markers": "python_version >= '3.10'",
+            "version": "==2.8.0"
         },
         "extras": {
             "hashes": [
@@ -59,17 +77,19 @@
         },
         "fixtures": {
             "hashes": [
-                "sha256:2a551b0421101de112d9497fb5f6fd25e5019391c0fbec9bad591ecae981420d",
-                "sha256:fcf0d60234f1544da717a9738325812de1f42c2fa085e2d9252d8fff5712b2ef"
+                "sha256:b7db64014732513f23d12b0c49ae527ba0c0c1f2667ec97d9136d67157ebce5d",
+                "sha256:c71ad55a9139bd20b3265c1d44c1a67fefb9efdddd79614096f538de63fbf4d8"
             ],
-            "version": "==3.0.0"
+            "markers": "python_version >= '3.10'",
+            "version": "==4.3.2"
         },
         "inflect": {
             "hashes": [
-                "sha256:51d3d0fe0db77fa9315c45ce5933a64d9043a36d42e8b1a082d3379dc39754cf",
-                "sha256:7a71eed8a666c0c2b0463bb850a9a5c51603699836bf251521374ceffeb9c322"
+                "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344",
+                "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f"
             ],
-            "version": "==0.3.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==7.5.0"
         },
         "irc": {
             "hashes": [
@@ -77,56 +97,64 @@
                 "sha256:cce90b6ed5e9bdbe9dfe1fbe6ff40752924a234656cad73744f4780086018e8b"
             ],
             "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==16.2"
-        },
-        "jaraco.classes": {
-            "hashes": [
-                "sha256:2c646c10deb2058dcb0e2b022a1124f5a1cbf8643fd09f5065fb5715982b4d9a",
-                "sha256:d101c45efd518a3ed76409a23ad2319bafeda13c3252395fe4d8ec195dd45f00"
-            ],
-            "version": "==1.5"
         },
         "jaraco.collections": {
             "hashes": [
-                "sha256:1e6904f662a31dce5ba5702eae342d7a66d178dd1e4195824385ce5988e361d5",
-                "sha256:d9cb10e7bca89b680381adb38476f6d782ec45751d802ce7387da5310b669515"
+                "sha256:dab81970bad6f0ab53b20745f1b01da37926e4c0fcd425046aa45e0d8efa18ed",
+                "sha256:ea3415ddfc50206b6ba7d09c3deb358b76a5f8c1ddc82be788e8e8bd151ebfa8"
             ],
-            "version": "==1.5.3"
+            "markers": "python_version >= '3.9'",
+            "version": "==5.2.1"
+        },
+        "jaraco.context": {
+            "hashes": [
+                "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535",
+                "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==6.1.2"
         },
         "jaraco.functools": {
             "hashes": [
-                "sha256:1d653159ae32e00f30390a6db355fdb091ea16ae27fea2dee8ed8f03e4eaa62d",
-                "sha256:60835b5fba2205d1cab2fd40884a0bb538693bc2f602d54c45ec3bab74c425fc"
+                "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176",
+                "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb"
             ],
-            "version": "==1.19"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.4.0"
         },
         "jaraco.itertools": {
             "hashes": [
-                "sha256:9ca316fbfffef258f80405547c1e08462c879108ce918b226ccd330b4f2de2fa",
-                "sha256:9f70940b6dd63ac12c1f60c3fac6c01163804a21a046848b0e58070788cacf75"
+                "sha256:06c8727afcad659e29ce78773870428500f4daf6f13b9c2f5154ddb21cbca90d",
+                "sha256:0d68d67a7261c3f3ac8ed39e8cd48ee93ef1b540e3d2066c76b92f17b61009c5"
             ],
-            "version": "==2.3"
+            "markers": "python_version >= '3.9'",
+            "version": "==6.4.3"
         },
         "jaraco.logging": {
             "hashes": [
-                "sha256:23b10eb0d65afe042fad16eabdf5956bdc863e110c5cf3fa1b4bc59f3a7f37a5",
-                "sha256:625977c56644d040d2023d8a3639d6b9ad0f490bc26e17be7bb5754a255178fb"
+                "sha256:c456f023cfa5e95c3e1b0c4a2be138caa7703811cf016ce3ded5b789c7a3605d",
+                "sha256:e7d6dc8368477ce69eb1d6ed851d805896a1ca942ce3fd1773580311b0b775fb"
             ],
-            "version": "==1.5.2"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.4.0"
         },
         "jaraco.stream": {
             "hashes": [
-                "sha256:2b56514708224864d93b8a6e916c02ae7ae4ce822f05946704719bb294971a1b",
-                "sha256:7e0829a81c373515f1c1ca16e39aa44b2f209fa8ce078daaa9532dabbfbd608d"
+                "sha256:41cec12393ab733870b54e3683564b95e68b82017428fcec56324f70e64c47c6",
+                "sha256:e2bc5028e721ed2cc852b96ec9a33f2b7664e9b2dbf87eefbe617d126641934b"
             ],
-            "version": "==1.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.0.4"
         },
         "jaraco.text": {
             "hashes": [
-                "sha256:d1b29e833f317629a7c8aff3c03521e61e1df6da188d7fa2f698b0281e1a5a2b",
-                "sha256:e5868da943d272af894a147680b1ac5902b82e59a2407e5c95d3f22ce8e049e2"
+                "sha256:034408ef073f72de919124e9934a12acd50d10bd139bea47732620fa964b0144",
+                "sha256:194e386aa5b15a6616019df87a6b29c00fd3c9c8b0475731b64633ca7afd495b"
             ],
-            "version": "==1.10.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.2.0"
         },
         "jinja2": {
             "hashes": [
@@ -142,26 +170,148 @@
             ],
             "version": "==1.0.0"
         },
+        "markdown-it-py": {
+            "hashes": [
+                "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147",
+                "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==4.0.0"
+        },
         "markupsafe": {
             "hashes": [
-                "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+                "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f",
+                "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a",
+                "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf",
+                "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19",
+                "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf",
+                "sha256:0f4b68347f8c5eab4a13419215bdfd7f8c9b19f2b25520968adfad23eb0ce60c",
+                "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175",
+                "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219",
+                "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb",
+                "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6",
+                "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab",
+                "sha256:15d939a21d546304880945ca1ecb8a039db6b4dc49b2c5a400387cdae6a62e26",
+                "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1",
+                "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce",
+                "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218",
+                "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634",
+                "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695",
+                "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad",
+                "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73",
+                "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c",
+                "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe",
+                "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa",
+                "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559",
+                "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa",
+                "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37",
+                "sha256:3537e01efc9d4dccdf77221fb1cb3b8e1a38d5428920e0657ce299b20324d758",
+                "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f",
+                "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8",
+                "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d",
+                "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c",
+                "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97",
+                "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a",
+                "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19",
+                "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9",
+                "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9",
+                "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc",
+                "sha256:591ae9f2a647529ca990bc681daebdd52c8791ff06c2bfa05b65163e28102ef2",
+                "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4",
+                "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354",
+                "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50",
+                "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698",
+                "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9",
+                "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b",
+                "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc",
+                "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115",
+                "sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e",
+                "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485",
+                "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f",
+                "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12",
+                "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025",
+                "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009",
+                "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d",
+                "sha256:949b8d66bc381ee8b007cd945914c721d9aba8e27f71959d750a46f7c282b20b",
+                "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a",
+                "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5",
+                "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f",
+                "sha256:a320721ab5a1aba0a233739394eb907f8c8da5c98c9181d1161e77a0c8e36f2d",
+                "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1",
+                "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287",
+                "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6",
+                "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f",
+                "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581",
+                "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed",
+                "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b",
+                "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c",
+                "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026",
+                "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8",
+                "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676",
+                "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6",
+                "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e",
+                "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d",
+                "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d",
+                "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01",
+                "sha256:df2449253ef108a379b8b5d6b43f4b1a8e81a061d6537becd5582fba5f9196d7",
+                "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419",
+                "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795",
+                "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1",
+                "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5",
+                "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d",
+                "sha256:e8fc20152abba6b83724d7ff268c249fa196d8259ff481f3b1476383f8f24e42",
+                "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe",
+                "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda",
+                "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e",
+                "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737",
+                "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523",
+                "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591",
+                "sha256:f71a396b3bf33ecaa1626c255855702aca4d3d9fea5e051b41ac59a9c1c41edc",
+                "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a",
+                "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50"
             ],
-            "version": "==1.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.0.3"
+        },
+        "mdurl": {
+            "hashes": [
+                "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+                "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.1.2"
         },
         "more-itertools": {
             "hashes": [
-                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
-                "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
-                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0"
+                "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804",
+                "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4"
             ],
-            "version": "==4.2.0"
+            "markers": "python_version >= '3.10'",
+            "version": "==11.0.2"
         },
         "pbr": {
             "hashes": [
-                "sha256:3747c6f017f2dc099986c325239661948f9f5176f6880d9fdef164cb664cd665",
-                "sha256:a9c27eb8f0e24e786e544b2dbaedb729c9d8546342b5a6818d8eda098ad4340d"
+                "sha256:b46004ec30a5324672683ec848aed9e8fc500b0d261d40a3229c2d2bbfcedc29",
+                "sha256:ff223894eb1cd271a98076b13d3badff3bb36c424074d26334cd25aebeecea6b"
             ],
-            "version": "==4.0.4"
+            "markers": "python_version >= '2.6'",
+            "version": "==7.0.3"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f",
+                "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.20.0"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==2.9.0.post0"
         },
         "python-etcd": {
             "hashes": [
@@ -172,31 +322,58 @@
         },
         "python-mimeparse": {
             "hashes": [
-                "sha256:76e4b03d700a641fd7761d3cd4fdbbdcd787eade1ebfac43f877016328334f78",
-                "sha256:a295f03ff20341491bfe4717a39cd0a8cc9afad619ba44b77e86b0ab8a2b8282"
+                "sha256:574062a06f2e1d416535c8d3b83ccc6ebe95941e74e2c5939fc010a12e37cc09",
+                "sha256:5b9a9dcf7aa82465e31bd667f5cb7000604811dce83554f1c8a43693a32cb303"
             ],
-            "version": "==1.6.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.0.0"
         },
         "pytz": {
             "hashes": [
-                "sha256:65ae0c8101309c45772196b21b74c46b2e5d11b6275c45d251b150d5da334555",
-                "sha256:c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749"
+                "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1",
+                "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a"
             ],
-            "version": "==2018.4"
+            "version": "==2026.1.post1"
+        },
+        "rich": {
+            "hashes": [
+                "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb",
+                "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"
+            ],
+            "markers": "python_full_version >= '3.9.0'",
+            "version": "==15.0.0"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9",
+                "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==82.0.1"
+        },
+        "shellingham": {
+            "hashes": [
+                "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686",
+                "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.5.4"
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+                "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
             ],
-            "version": "==1.11.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.17.0"
         },
         "tempora": {
             "hashes": [
-                "sha256:4be862dbdc6fcbcc57f4b355258daa41fc0932af99680142bfa20836379f57a5",
-                "sha256:e7496537422e72bb331e460b5d1c864dd95d42474ca454a61ab8760be37a2f26"
+                "sha256:6945ec409ca930e5040490931dc0d8f516f2cd9798eb175dc3b3c6a0fc481ea2",
+                "sha256:abb5d9ec790cc5e4f9431778029ba3e3d9ba9bd50cb306dad824824b2b362dcd"
             ],
-            "version": "==1.11"
+            "markers": "python_version >= '3.9'",
+            "version": "==5.8.1"
         },
         "testtools": {
             "hashes": [
@@ -213,6 +390,38 @@
             ],
             "version": "==1.4.0"
         },
+        "typeguard": {
+            "hashes": [
+                "sha256:44d2bf329d49a244110a090b55f5f91aa82d9a9834ebfd30bcc73651e4a8cc40",
+                "sha256:f6f8ecbbc819c9bc749983cc67c02391e16a9b43b8b27f15dc70ed7c4a007274"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==4.5.1"
+        },
+        "typer": {
+            "hashes": [
+                "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930",
+                "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==0.25.0"
+        },
+        "typer-slim": {
+            "hashes": [
+                "sha256:d5d7ee1ee2834d5020c7c616ed5e0d0f29b9a4b1dd283bdebae198ec09778d0e",
+                "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==0.24.0"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+                "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==4.15.0"
+        },
         "unittest2": {
             "hashes": [
                 "sha256:13f77d0875db6d9b435e1d4f41e74ad4cc2eb6e1d5c824996092b3430f088bb8",
@@ -222,10 +431,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
-                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
+                "sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f",
+                "sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14"
             ],
-            "version": "==1.23"
+            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.26.16"
         }
     },
     "develop": {}


### PR DESCRIPTION
# 🔒 Security Vulnerability Fixes

This PR addresses security vulnerabilities detected by Snyk for project **snyk-python-plugin**.

## 🔍 Test Failure Analysis

⚠️ **Tests failed after applying security fixes.**

This could be due to:
- Breaking changes in the upgraded packages
- Missing test dependencies or setup
- Environment-specific issues

**Packages upgraded:**
- `snyk-poetry-lockfile-parser`
- `@snyk/dep-graph`


**Action Required:** Please review the test output and determine if:
1. Tests need to be updated for breaking changes
2. Additional setup is needed in the test environment
3. The upgrade introduced actual bugs (in which case, consider alternative fixes)

<details>
<summary>View Test Output</summary>

```

> test
> npm run test:jest


> test:jest
> jest

  console.warn
    [snyk-python-plugin] Filtered contamination from JSON output: 38 characters removed. Contamination content: "pip_system_certs configuration loaded\n"

      30 |
      31 |         if (filteredContent.length > 0) {
    > 32 |           console.warn(
         |                   ^
      33 |             `[snyk-python-plugin] Filtered contamination from JSON output: ` +
      34 |               `${filteredContent.length} characters removed. ` +
      35 |               `Contamination content: ${JSON.stringify(

      at parseJsonWithContaminationFiltering (lib/dependencies/inspect-implementation.ts:32:19)
      at Object.<anonymous> (test/contamination-filtering.spec.ts:39:57)

  console.warn
    [snyk-python-plugin] Filtered contamination from JSON output: 43 characters removed. Contamination content: "\npip_system certificate validation complete"

      30 |
      31 |         if (filteredContent.length > 0) {
    > 32 |           console.warn(
         |                   ^
      33 |             `[snyk-python-plugin] Filtered contamination from JSON output: ` +
      34 |               `${filteredContent.length} characters removed. ` +
      35 |               `Contamination content: ${JSON.stringify(

      at parseJsonWithContaminationFiltering (lib/dependencies/inspect-implementation.ts:32:19)
      at Object.<anonymous> (test/contamination-filtering.spec.ts:45:57)

  console.warn
    [snyk-python-plugin] Filtered contamination from JSON output: 53 characters removed. Contamination content: "SSL certificate verification\n\npip_system cleanup done"

      30 |
      31 |         if (filteredContent.length > 0) {
    > 32 |           console.warn(
         |                   ^
      33 |             `[snyk-python-plugin] Filtered contamination from JSON output: ` +
      34 |               `${filteredContent.length} characters removed. ` +
      35 |               `Contamination content: ${JSON.stringify(

      at parseJsonWithContaminationFiltering (lib/dependencies/inspect-implementation.ts:32:19)
      at Object.<anonymous> (test/contamination-filtering.spec.ts:51:57)

  console.warn
    [snyk-python-plugin] Filtered contamination from JSON output: 42 characters removed. Contamination content: "prefix contamination  suffix contamination"

      30 |
      31 |         if (filteredContent.length > 0) {
    > 32 |           console.warn(
         |                   ^
      33 |             `[snyk-python-plugin] Filtered contamination from JSON output: ` +
      34 |               `${filteredContent.length} characters removed. ` +
      35 |               `Contamination content: ${JSON.stringify(

      at parseJsonWithContaminationFiltering (lib/dependencies/inspect-implementation.ts:32:19)
      at Object.<anonymous> (test/contamination-filtering.spec.ts:59:57)

  console.warn
    [snyk-python-plugin] Filtered contamination from JSON output: 71 characters removed. Contamination content: "Loading certificates...\npip_system_certs initializing\n\nCleanup complete"

      30 |
      31 |         if (filteredContent.length > 0) {
    > 32 |           console.warn(
         |                   ^
      33 |             `[snyk-python-plugin] Filtered contamination from JSON output: ` +
      34 |               `${filteredContent.length} characters removed. ` +
      35 |               `Contamination content: ${JSON.stringify(

      at parseJsonWithContaminationFiltering (lib/dependencies/inspect-implementation.ts:32:19)
      at Object.<anonymous> (test/contamination-filtering.spec.ts:71:57)

ts-jest[versions] (WARN) Version 5.9.3 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=4.3.0 <5.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
ts-jest[versions] (WARN) Version 5.9.3 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=4.3.0 <5.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
ts-jest[versions] (WARN) Version 5.9.3 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=4.3.0 <5.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
ts-jest[versions] (WARN) Version 5.9.3 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=4.3.0 <5.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
ts-jest[versions] (WARN) Version 5.9.3 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=4.3.0 <5.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
ts-jest[versions] (WARN) Version 5.9.3 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=4.3.0 <5.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
ts-jest[versions] (WARN) Version 5.9.3 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=4.3.0 <5.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
PASS test/unit/build-args.spec.ts
  build args
    ✓ should return expected args
    ✓ should return expected args when allowMissing is true
    ✓ should return expected args when includeDevDeps is true (1 ms)
    ✓ should return expected args when allowMissing and includeDevDeps are true

PASS test/unit/poetry.spec.ts
  getPoetryDepencies
    ✓ should use absolute targetFile path directly without joining to root (2 ms)
    ✓ should throw exception when manifest does not exist
    ✓ should throw exception when lockfile does not exist (1 ms)
    ✓ should throw exception when lockfile parser throws exception

PASS test/contamination-filtering.spec.ts
  parseJsonWithContaminationFiltering
    Strategy 1: Clean JSON (most common case)
      ✓ should parse clean JSON output successfully (1 ms)
      ✓ should handle JSON with extra whitespace
    Strategy 2: JSON extraction from contaminated output
      ✓ should extract valid JSON from output with prefix contamination (22 ms)
      ✓ should extract valid JSON from output with suffix contamination (1 ms)
      ✓ should extract valid JSON from output with surrounding contamination (1 ms)
    Strategy 2 edge cases
      ✓ should extract JSON using brace boundaries (1 ms)
      ✓ should find valid JSON line in multi-line output (1 ms)
    Error handling
      ✓ should provide descriptive error with original output for debugging (5 ms)

PASS test/unit/sub-process.spec.ts
  Test sub-process.ts
    ✓ test restoring proxy setting in executeSync() (313 ms)
    ✓ test executeSync() (200 ms)

PASS test/unit/inspect-implementation.spec.ts
  Test inspect-implementation.ts
    inspectInstalledDeps
      ✓ should call tmp.dirSync with tmpdir option when SNYK_TMP_PATH is set (232 ms)
      ✓ should call tmp.dirSync without tmpdir option when SNYK_TMP_PATH is not set (232 ms)

FAIL test/unit/setup_file.spec.ts
  Test setup_file.py
    ✕ parse works for 'import setuptools;setuptools.setup(name="test")' (168 ms)
    ✕ parse works for 'from setuptools import setup;setup(name="test")' (139 ms)
    ✓ should work when --dev-deps is set but not dev-packages in Pipfile (203 ms)

  ● Test setup_file.py › parse works for 'import setuptools;setuptools.setup(name="test")'

    expect(received).toBe(expected) // Object.is equality

    Expected: 0
    Received: 1

      14 |     );
      15 |
    > 16 |     expect(result.status).toBe(0);
         |                           ^
      17 |   });
      18 |
      19 |   it('should work when --dev-deps is set but not dev-packages in Pipfile', async () => {

      at test/unit/setup_file.spec.ts:16:27

  ● Test setup_file.py › parse works for 'from setuptools import setup;setup(name="test")'

    expect(received).toBe(expected) // Object.is equality

    Expected: 0
    Received: 1

      14 |     );
      15 |
    > 16 |     expect(result.status).toBe(0);
         |                           ^
      17 |   });
      18 |
      19 |   it('should work when --dev-deps is set but not dev-packages in Pipfile', async () => {

      at test/unit/setup_file.spec.ts:16:27

FAIL test/system/inspect.spec.ts (138.517 s)
  inspect
    ✕ should return correct target file for poetry project when relative path to poetry lock file is passed (4 ms)
    ✕ should return correct target file for poetry v2 project when relative path to poetry lock file is passed (3 ms)
    when doing inspect with --only-provenance
      ✓ should get a valid dependency graph for workspace = pip-app (190 ms)
      ✓ should get a valid dependency graph for workspace = pipfile-pipapp (1047 ms)
      ✓ should get a valid dependency graph for workspace = setup_py-app (231 ms)
      ✓ should get a valid dependency graph for workspace = pipfile-optional-dependencies (939 ms)
    when testing pip projects
      ✓ should get a valid dependency graph for workspace = pip-app-local-whl-file (6189 ms)
      ✓ should get a valid dependency graph for workspace = pip-app (1640 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-bom (2156 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-deps-with-urls (2206 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-without-markupsafe (2364 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-deps-not-installed (3460 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-trusted-host (3438 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-deps-with-dashes (2094 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-with-openapi_spec_validator (3004 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-deps-conditional (2153 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-deps-editable (9265 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-deps-canonicalization (4256 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-optional-dependencies (4077 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-dev-alpha-beta-python-version (2351 ms)
      ✓ should get correct pkgIdProvenance labels for packages in graph for workspace = pip-app (1737 ms)
      ✓ should get correct pkgIdProvenance labels for packages in graph for workspace = pip-app (1608 ms)
      ✓ should get correct pkgIdProvenance labels for packages in graph for workspace = pip-app-deps-conditional (330 ms)
      ✓ should get correct pkgIdProvenance labels for packages in graph for workspace = pip-app-deps-editable (6103 ms)
      ✓ should get correct pkgIdProvenance labels for packages in graph for workspace = pip-app (1837 ms)
      ✓ should get correct pkgIdProvenance labels for packages in graph for workspace = pip-app-deps-with-dashes (416 ms)
      ✓ should succeed on package name/local dir name clash (3225 ms)
      ✓ should get a valid dependency graph for workspace = pip-app without setuptools previously installed (2689 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-bom without setuptools previously installed (532 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-deps-with-urls without setuptools previously installed (578 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-without-markupsafe without setuptools previously installed (858 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-deps-not-installed without setuptools previously installed (584 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-trusted-host without setuptools previously installed (581 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-deps-with-dashes without setuptools previously installed (569 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-with-openapi_spec_validator without setuptools previously installed (639 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-deps-conditional without setuptools previously installed (574 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-deps-editable without setuptools previously installed (6229 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-deps-canonicalization without setuptools previously installed (1209 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-optional-dependencies without setuptools previously installed (1223 ms)
      ✓ should get a valid dependency graph for workspace = pip-app-dev-alpha-beta-python-version without setuptools previously installed (584 ms)
      ✓ should fail on missing transitive dependencies (1887 ms)
      ✓ should fail on nonexistent referenced local depedency (1579 ms)
      ✓ should not fail on nonexistent referenced local depedency when --skip-unresolved (129 ms)
    Circular deps
      ✓ Should get a valid dependency graph for circular dependencies (2346 ms)
    poetry projects
      ✕ should return expected dependencies for poetry-app (6 ms)
      ✕ should return expected dependencies for poetry-v2-app (4 ms)
      ✕ should return expected dependencies for poetry-optional-dependencies (7 ms)
      ✕ should return expected dependencies for poetry-v2-app-optional-dependencies (7 ms)
    Pipfile projects
      ✓ should return correct target file for pipenv project when relative path to pipfile lock file is passed (21 ms)
    when testing pipenv projects simulating pipenv install
      ✓ should get a valid dependency graph for workspace = pipfile-pipapp-pinned (14841 ms)
      ✓ should get a valid dependency graph for workspace = pipenv-app (7163 ms)
      ✓ should get correct pkgIdProvenance labels for packages in graph for workspace = pipfile-pipapp-pinned (1764 ms)
    when generating Pipfile depGraphs 
      ✓ should get a valid dependency graph for workspace = pipfile-pipapp-pinned (1000 ms)
      ✓ should get a valid dependency graph for workspace = pipenv-app (987 ms)
      ✓ should get a valid dependency graph for workspace = pipfile-pipapp (979 ms)
      ✓ should get a valid dependency graph for workspace = pipfile-nested-dirs (991 ms)
      ✓ should fail with no deps or dev-deps (969 ms)
    setup.py projects
      ✓ should return correct target file for setuptools project when relative path to setup lock file is passed (19 ms)
    setup.py projects without mocks
      ✓ should get a valid dependency graph for workspace = setup_py-app (7967 ms)
    dep-graph
      ✓ should return dep graph for very dense input (36 ms)
      ✓ projectName option should set the dep graph root node name (24 ms)
    error scenarios
      manifest file is empty
        ✓ should throw PythonEmptyManifestError (20 ms)
      required packages were not installed
        ✓ should throw PythonRequiredPackagesMissingError (18 ms)

  ● inspect › poetry projects › should return expected dependencies for poetry-app

    Error processing poetry project. Could not find 'python' on your PATH.
    stderr: spawn python ENOENT
    stdout:

      58 |     }
      59 |
    > 60 |     throw new Error('Error processing poetry project. ' + errorMessage);
         |           ^
      61 |   }
      62 | }
      63 |

      at lib/dependencies/poetry.ts:60:11
          at Generator.throw (<anonymous>)
      at rejected (node_modules/tslib/tslib.js:168:69)

  ● inspect › poetry projects › should return expected dependencies for poetry-v2-app

    Error processing poetry project. Could not find 'python' on your PATH.
    stderr: spawn python ENOENT
    stdout:

      58 |     }
      59 |
    > 60 |     throw new Error('Error processing poetry project. ' + errorMessage);
         |           ^
      61 |   }
      62 | }
      63 |

      at lib/dependencies/poetry.ts:60:11
          at Generator.throw (<anonymous>)
      at rejected (node_modules/tslib/tslib.js:168:69)

  ● inspect › poetry projects › should return expected dependencies for poetry-optional-dependencies

    Error processing poetry project. Could not find 'python' on your PATH.
    stderr: spawn python ENOENT
    stdout:

      58 |     }
      59 |
    > 60 |     throw new Error('Error processing poetry project. ' + errorMessage);
         |           ^
      61 |   }
      62 | }
      63 |

      at lib/dependencies/poetry.ts:60:11
          at Generator.throw (<anonymous>)
      at rejected (node_modules/tslib/tslib.js:168:69)

  ● inspect › poetry projects › should return expected dependencies for poetry-v2-app-optional-dependencies

    Error processing poetry project. Could not find 'python' on your PATH.
    stderr: spawn python ENOENT
    stdout:

      58 |     }
      59 |
    > 60 |     throw new Error('Error processing poetry project. ' + errorMessage);
         |           ^
      61 |   }
      62 | }
      63 |

      at lib/dependencies/poetry.ts:60:11
          at Generator.throw (<anonymous>)
      at rejected (node_modules/tslib/tslib.js:168:69)

  ● inspect › should return correct target file for poetry project when relative path to poetry lock file is passed

    Error processing poetry project. Could not find 'python' on your PATH.
    stderr: spawn python ENOENT
    stdout:

      58 |     }
      59 |
    > 60 |     throw new Error('Error processing poetry project. ' + errorMessage);
         |           ^
      61 |   }
      62 | }
      63 |

      at lib/dependencies/poetry.ts:60:11
          at Generator.throw (<anonymous>)
      at rejected (node_modules/tslib/tslib.js:168:69)

  ● inspect › should return correct target file for poetry v2 project when relative path to poetry lock file is passed

    Error processing poetry project. Could not find 'python' on your PATH.
    stderr: spawn python ENOENT
    stdout:

      58 |     }
      59 |
    > 60 |     throw new Error('Error processing poetry project. ' + errorMessage);
         |           ^
      61 |   }
      62 | }
      63 |

      at lib/dependencies/poetry.ts:60:11
          at Generator.throw (<anonymous>)
      at rejected (node_modules/tslib/tslib.js:168:69)

Test Suites: 2 failed, 5 passed, 7 total
Tests:       8 failed, 78 passed, 86 total
Snapshots:   0 total
Time:        139.037 s
Ran all test suites.

```

</details>


---

## Fixed Vulnerabilities

### high - Arbitrary Code Injection
- **CVE:** CVE-2026-4800
- **Package:** snyk-poetry-lockfile-parser
- **Fix:** Updated snyk-poetry-lockfile-parser from 1.9.1 to 1.9.2

### high - Arbitrary Code Injection
- **CVE:** CVE-2026-4800
- **Package:** @snyk/dep-graph
- **Fix:** Updated @snyk/dep-graph from 1.28.1 to 2.16.8


---

## 📝 Testing Recommendations

Please verify:
1. All tests pass
2. Application builds successfully
3. No breaking changes in upgraded dependencies

---

*Generated by Vuln-Bot 🤖*
