### PR TITLE
🔒 Fix 1 security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "snyk-poetry-lockfile-parser": "^1.9.1",
     "tmp": "0.2.3"
   },
+  "overrides": {
+    "lodash": "^4.18.1"
+  },
   "devDependencies": {
     "@types/jest": "^28.1.3",
     "@types/node": "^20",


### PR DESCRIPTION
# 🔒 Security Vulnerability Fixes

This PR addresses security vulnerabilities detected by Snyk for project **snyk-python-plugin**.

## Fixed Vulnerabilities

### high - Arbitrary Code Injection
- **CVE:** CVE-2026-4800
- **Package:** lodash
- **Fix:** Upgraded from 4.17.21 to 4.18.1

**Reason:** Adding an npm overrides entry for lodash at ^4.18.1 forces all transitive dependents (including snyk-poetry-lockfile-parser) to use lodash 4.18.1 instead of the previously allowed 4.17.21. This patches the prototype pollution vulnerability present in lodash versions prior to 4.18.x.

**Dependency Path:**
- `snyk-python-plugin > snyk-poetry-lockfile-parser > lodash`


---

## 📝 Testing Recommendations

Please verify:
1. All tests pass
2. Application builds successfully
3. No breaking changes in upgraded dependencies

---

*Generated by Vuln-Bot 🤖*
