### PR TITLE
🔒 Fix 1 security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "snyk-poetry-lockfile-parser": "^1.9.1",
     "tmp": "0.2.3"
   },
+  "overrides": {
+    "lodash": "^4.18.1"
+  },
   "devDependencies": {
     "@types/jest": "^28.1.3",
     "@types/node": "^20",


### PR DESCRIPTION
# 🔒 Security Vulnerability Fixes

This PR addresses security vulnerabilities detected by Snyk for project **snyk-python-plugin**.

## Fixed Vulnerabilities

### high - Arbitrary Code Injection
- **CVE:** CVE-2026-4800
- **Package:** lodash
- **Fix:** Upgraded from 4.17.21 to 4.18.1

**Reason:** Added npm override to force lodash to >=4.18.1 across all transitive dependencies. snyk-poetry-lockfile-parser@1.9.1 required lodash ^4.17.21 which is vulnerable; the override ensures lodash 4.18.1 (the patched version) is installed regardless of which version of snyk-poetry-lockfile-parser npm resolves to within the ^1.9.1 range

**Dependency Path:**
- `snyk-python-plugin > snyk-poetry-lockfile-parser > lodash`


---

## 📝 Testing Recommendations

Please verify:
1. All tests pass
2. Application builds successfully
3. No breaking changes in upgraded dependencies

---

*Generated by Vuln-Bot 🤖*
