### PR TITLE
fix: resolve 1 security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@snyk/dep-graph": "^1.28.1",
     "@snyk/error-catalog-nodejs-public": "^5.77.0",
     "shescape": "2.1.6",
-    "snyk-poetry-lockfile-parser": "^1.9.1",
+    "snyk-poetry-lockfile-parser": "^1.9.2",
     "tmp": "0.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
# 🔒 Security Vulnerability Fixes

This PR addresses 1 security vulnerabilities detected by Snyk.

## ✅ Fixed Vulnerabilities

- **high** - Arbitrary Code Injection (CVE-2026-4800)
  - Upgraded from ^1.9.1 to ^1.9.2

**Reason:** Upgrading snyk-poetry-lockfile-parser to ^1.9.2 explicitly pins the resolved version to 1.9.2, which declares lodash ^4.18.1, ensuring lodash resolves to 4.18.1 and cannot fall back to the vulnerable 4.17.23 range

**Dependency Path:**
- `snyk-python-plugin > snyk-poetry-lockfile-parser > lodash`
