### PR TITLE
fix: resolve 2 security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "ts-jest": "^28.0.8",
     "ts-node": "^8.10.2",
     "typescript": "^5.8.3"
+  },
+  "overrides": {
+    "uuid": ">=11.1.1"
   }
 }


### PR DESCRIPTION
# 🔒 Security Vulnerability Fixes

This PR addresses 2 security vulnerabilities detected by Snyk.

## ✅ Fixed Vulnerabilities

- **high** - Arbitrary Code Injection (CVE-2026-4800)
  - Upgraded **lodash** from 4.17.23 to 4.18.1

**Reason:** snyk-poetry-lockfile-parser@1.9.2 (latest in ^1.9.1) declares lodash@^4.18.1, which cannot resolve to the vulnerable 4.17.23. No package.json change needed; generating a lockfile locks in the safe version.

**Dependency Path:**
- `snyk-python-plugin > snyk-poetry-lockfile-parser > lodash`
- **high** - Improper Validation of Specified Index, Position, or Offset in Input (CVE-2026-41907)
  - Upgraded **uuid** from 11.1.0 to 11.1.1

**Reason:** @snyk/error-catalog-nodejs-public@5.81.0 is the absolute latest and still declares uuid@^11.1.0, which allows the vulnerable 11.1.0. Override added to package.json overrides pinning uuid to >=11.1.1 across all resolution paths.

**Dependency Path:**
- `snyk-python-plugin > @snyk/error-catalog-nodejs-public > uuid`
