### PR TITLE
fix: resolve 2 security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,10 @@
     "ts-jest": "^28.0.8",
     "ts-node": "^8.10.2",
     "typescript": "^5.8.3"
+  },
+  "overrides": {
+    "@snyk/error-catalog-nodejs-public": {
+      "uuid": "11.1.1"
+    }
   }
 }


### PR DESCRIPTION
# 🔒 Security Vulnerability Fixes

This PR addresses 2 security vulnerabilities detected by Snyk.

## ✅ Fixed Vulnerabilities

- **high** - Arbitrary Code Injection (CVE-2026-4800)
  - Upgraded **lodash** from 4.17.23 to 4.18.1

**Reason:** snyk-poetry-lockfile-parser@1.9.2 already declares lodash@^4.18.1 (minimum 4.18.1 > vulnerable 4.17.23). No package.json change needed; with no lockfile present, npm install always resolves to a safe version.

**Dependency Path:**
- `snyk-python-plugin > snyk-poetry-lockfile-parser > lodash`
- **high** - Improper Validation of Specified Index, Position, or Offset in Input (CVE-2026-41907)
  - Upgraded **uuid** from 11.1.0 to 11.1.1

**Reason:** @snyk/error-catalog-nodejs-public@5.81.0 is the absolute latest and still declares uuid@^11.1.0, which permits the vulnerable 11.1.0. Override scoped to @snyk/error-catalog-nodejs-public forces uuid@11.1.1 within that subtree.

**Dependency Path:**
- `snyk-python-plugin > @snyk/error-catalog-nodejs-public > uuid`
