### PR TITLE
fix: resolve 1 security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
     "snyk-poetry-lockfile-parser": "^1.9.1",
     "tmp": "0.2.3"
   },
+  "overrides": {
+    "@snyk/error-catalog-nodejs-public": {
+      "uuid": "11.1.1"
+    }
+  },
   "devDependencies": {
     "@types/jest": "^28.1.3",
     "@types/node": "^20",


### PR DESCRIPTION
# 🔒 Security Vulnerability Fixes

This PR addresses 1 security vulnerabilities detected by Snyk.

## ✅ Fixed Vulnerabilities

- **high** - Improper Validation of Specified Index, Position, or Offset in Input (CVE-2026-41907)
  - Upgraded **uuid** from 11.1.0 to 11.1.1

**Reason:** @snyk/error-catalog-nodejs-public@5.81.0 is the absolute latest and still declares uuid@^11.1.0, which includes the vulnerable 11.1.0 floor. No v6+ of the parent exists. Override scoped to @snyk/error-catalog-nodejs-public forces uuid@11.1.1 (the only same-major patch above the vulnerable version) within that subtree. lodash vulnerability 4bc1df53-6d77-47e4-a3d0-5bf1f53ecdfe requires no package.json change — snyk-poetry-lockfile-parser@1.9.2 already declares lodash@^4.18.1 and the declared range ^1.9.1 in package.json satisfies that version, so npm install without a lockfile resolves safely.

**Dependency Path:**
- `snyk-python-plugin > @snyk/error-catalog-nodejs-public > uuid`
