### PR TITLE
fix: resolve 2 security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,10 @@
     "ts-jest": "^28.0.8",
     "ts-node": "^8.10.2",
     "typescript": "^5.8.3"
+  },
+  "overrides": {
+    "@snyk/error-catalog-nodejs-public": {
+      "uuid": "11.1.1"
+    }
   }
 }


### PR DESCRIPTION
# 🔒 Security Vulnerability Fixes

This PR addresses 2 security vulnerabilities detected by Snyk.

## ✅ Fixed Vulnerabilities

- **high** - Improper Validation of Specified Index, Position, or Offset in Input (CVE-2026-41907)
  - Upgraded **uuid** from 11.1.0 to 11.1.1

**Reason:** @snyk/error-catalog-nodejs-public@5.81.0 is already at its absolute latest and still declares uuid@^11.1.0 (vulnerable floor). Override scoped to @snyk/error-catalog-nodejs-public forces uuid@11.1.1 (same-major patch, non-vulnerable) within that subtree.

**Dependency Path:**
- `snyk-python-plugin > @snyk/error-catalog-nodejs-public > uuid`
- **high** - Arbitrary Code Injection (CVE-2026-4800)
  - Upgraded **lodash** from 4.17.23 to 4.18.1

**Reason:** snyk-poetry-lockfile-parser@1.9.2 (latest, already within declared ^1.9.1) declares lodash@^4.18.1, excluding the vulnerable 4.17.23. Lockfile regenerated via npm update to resolve to 4.18.1; no package.json change required.

**Dependency Path:**
- `snyk-python-plugin > snyk-poetry-lockfile-parser > lodash`
