### PR TITLE
fix: resolve 2 security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
     "snyk-poetry-lockfile-parser": "^1.9.1",
     "tmp": "0.2.3"
   },
+  "overrides": {
+    "@snyk/error-catalog-nodejs-public": {
+      "uuid": "11.1.1"
+    }
+  },
   "devDependencies": {
     "@types/jest": "^28.1.3",
     "@types/node": "^20",


### PR DESCRIPTION
# 🔒 Security Vulnerability Fixes

This PR addresses 2 security vulnerabilities detected by Snyk.

## ✅ Fixed Vulnerabilities

- **high** - Arbitrary Code Injection (CVE-2026-4800)
  - Upgraded **lodash** from 4.17.23 to 4.18.1

**Reason:** snyk-poetry-lockfile-parser@1.9.2 declares lodash@'^4.18.1' (minimum 4.18.1 > vulnerable 4.17.23). The declared range ^1.9.1 already satisfies 1.9.2; lockfile updated via npm update to pull in 1.9.2 and its fixed lodash. No package.json change required.

**Dependency Path:**
- `snyk-python-plugin > snyk-poetry-lockfile-parser > lodash`
- **high** - Improper Validation of Specified Index, Position, or Offset in Input (CVE-2026-41907)
  - Upgraded **uuid** from 11.1.0 to 11.1.1

**Reason:** @snyk/error-catalog-nodejs-public@5.81.0 (absolute latest) still declares uuid@'^11.1.0' whose minimum is 11.1.0 (the vulnerable version itself). Override scoped to @snyk/error-catalog-nodejs-public forces uuid@11.1.1 (same-major patch) within that subtree.

**Dependency Path:**
- `snyk-python-plugin > @snyk/error-catalog-nodejs-public > uuid`
