### PR TITLE
fix: resolve 2 security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,13 @@
     "@snyk/dep-graph": "^1.28.1",
     "@snyk/error-catalog-nodejs-public": "^5.77.0",
     "shescape": "2.1.6",
-    "snyk-poetry-lockfile-parser": "^1.9.1",
+    "snyk-poetry-lockfile-parser": "^1.9.2",
     "tmp": "0.2.3"
+  },
+  "overrides": {
+    "@snyk/error-catalog-nodejs-public": {
+      "uuid": "11.1.1"
+    }
   },
   "devDependencies": {
     "@types/jest": "^28.1.3",


### PR DESCRIPTION
# 🔒 Security Vulnerability Fixes

This PR addresses 2 security vulnerabilities detected by Snyk.

## ✅ Fixed Vulnerabilities

- **high** - Arbitrary Code Injection (CVE-2026-4800)
  - Upgraded **snyk-poetry-lockfile-parser** from ^1.9.1 to ^1.9.2

**Reason:** snyk-poetry-lockfile-parser@1.9.2 declares lodash@^4.18.1 (minimum 4.18.1), which cannot resolve to the vulnerable 4.17.23. Tightening the declared range to ^1.9.2 ensures fresh installs always get the fixed lodash.

**Dependency Path:**
- `snyk-python-plugin > snyk-poetry-lockfile-parser > lodash`
- **high** - Improper Validation of Specified Index, Position, or Offset in Input (CVE-2026-41907)
  - Upgraded **uuid** from ^11.1.0 to 11.1.1

**Reason:** @snyk/error-catalog-nodejs-public@5.81.0 is already at same-major latest and still declares uuid@^11.1.0 (bottoms out at vulnerable 11.1.0). Override scoped to @snyk/error-catalog-nodejs-public forces uuid@11.1.1 within that subtree.

**Dependency Path:**
- `snyk-python-plugin > @snyk/error-catalog-nodejs-public > uuid`
