### PR TITLE
fix: resolve 1 security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "snyk-poetry-lockfile-parser": "^1.9.1",
     "tmp": "0.2.3"
   },
+  "overrides": {
+    "lodash@4": "4.18.1"
+  },
   "devDependencies": {
     "@types/jest": "^28.1.3",
     "@types/node": "^20",


### PR DESCRIPTION
# 🔒 Security Vulnerability Fixes

This PR addresses 1 security vulnerabilities detected by Snyk.

## ✅ Fixed Vulnerabilities

**HIGH** — Arbitrary Code Injection (CVE-2026-4800)

Upgraded **lodash** from 4.17.23 to 4.18.1

**Reason:** lodash@4.17.23 is vulnerable; same-major latest is 4.18.1. Direct parents are unknown (npm ls returned empty, no lockfile present). Versioned override key @4 pins all 4.x consumers to the fixed version without risking a cross-major jump.

**Dependency Path:**
- `snyk-python-plugin > (unknown parent) > lodash`
