### PR TITLE
chore: upgrade tmp to avoid solve CVE-2026-44705

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@snyk/error-catalog-nodejs-public": "^5.77.0",
     "shescape": "2.1.6",
     "snyk-poetry-lockfile-parser": "^1.9.1",
-    "tmp": "0.2.3"
+    "tmp": "0.2.7"
   },
   "devDependencies": {
     "@types/jest": "^28.1.3",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Upgrades the `tmp` package to avoid [CVE-2026-44705](https://advisories.gitlab.com/npm/tmp/CVE-2026-44705/)


#### Where should the reviewer start?


#### How should this be manually tested?

> npm test

Still, same results as in snyk:main branch


#### Any background context you want to provide?

Related PR: https://github.com/snyk/cli/pull/6875


#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CLI-1534

#### Screenshots

`npm test`: old and new
<img width="896" height="1319" alt="image" src="https://github.com/user-attachments/assets/7d5cbccc-e503-4273-bdea-ffb01444e77b" />


#### Additional questions
