### PR TITLE
fix: resolve 2 security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "@snyk/dep-graph": "^1.28.1",
     "@snyk/error-catalog-nodejs-public": "^5.77.0",
     "shescape": "2.1.6",
-    "snyk-poetry-lockfile-parser": "^1.9.1",
-    "tmp": "0.2.3"
+    "snyk-poetry-lockfile-parser": "^1.9.2",
+    "tmp": "^0.2.7"
   },
   "devDependencies": {
     "@types/jest": "^28.1.3",


### PR DESCRIPTION
# 🔒 Security Vulnerability Fixes

This PR addresses 2 security vulnerabilities detected by Snyk.

## ✅ Fixed Vulnerabilities

**HIGH** — Directory Traversal (CVE-2026-44705)

Upgraded **tmp** from 0.2.3 to ^0.2.7

**Reason:** Direct dependency upgraded from 0.2.3 to ^0.2.7; same-major latest 0.2.7 is newer than vulnerable 0.2.3.

**Dependency Path:**
- `snyk-python-plugin > tmp`

---

**HIGH** — Arbitrary Code Injection (CVE-2026-4800)

Upgraded **snyk-poetry-lockfile-parser** from ^1.9.1 to ^1.9.2

**Reason:** snyk-poetry-lockfile-parser@1.9.2 declares lodash@^4.18.1 (fixed); tightening the declared range from ^1.9.1 to ^1.9.2 ensures fresh installs resolve lodash to >=4.18.1, eliminating the vulnerable 4.17.23.

**Dependency Path:**
- `snyk-python-plugin > snyk-poetry-lockfile-parser > lodash`
