### PR TITLE
feat: emit component-metadata labels for poetry projects

### DIFF
--- a/lib/dependencies/index.ts
+++ b/lib/dependencies/index.ts
@@ -29,7 +29,9 @@ export async function getDependencies(
   }
   let command = options.command || 'python';
   const includeDevDeps = !!(options.dev || false);
-  const includeComponentMetadata = !!(options.includeComponentMetadata || false);
+  const includeComponentMetadata = !!(
+    options.includeComponentMetadata || false
+  );
 
   // handle poetry projects by parsing manifest & lockfile and return a dep-graph
   if (path.basename(targetFile) === FILENAMES.poetry.lockfile) {

--- a/lib/dependencies/index.ts
+++ b/lib/dependencies/index.ts
@@ -12,6 +12,7 @@ export interface PythonInspectOptions {
   args?: string[];
   projectName?: string; // Allow providing a project name for the root node and package
   allowEmpty?: boolean; // Allow manifest without dependencies (mostly for SCM)
+  includeComponentMetadata?: boolean; // Emit hash:/distribution: labels on dep-graph nodes (poetry only)
 }
 
 type Options = api.SingleSubprojectInspectOptions & PythonInspectOptions;
@@ -28,10 +29,17 @@ export async function getDependencies(
   }
   let command = options.command || 'python';
   const includeDevDeps = !!(options.dev || false);
+  const includeComponentMetadata = !!(options.includeComponentMetadata || false);
 
   // handle poetry projects by parsing manifest & lockfile and return a dep-graph
   if (path.basename(targetFile) === FILENAMES.poetry.lockfile) {
-    return getPoetryDependencies(command, root, targetFile, includeDevDeps);
+    return getPoetryDependencies(
+      command,
+      root,
+      targetFile,
+      includeDevDeps,
+      includeComponentMetadata
+    );
   }
 
   let baseargs: string[] = [];

--- a/lib/dependencies/poetry.ts
+++ b/lib/dependencies/poetry.ts
@@ -9,7 +9,8 @@ export async function getPoetryDependencies(
   command: string,
   root: string,
   targetFile: string,
-  includeDevDeps = false
+  includeDevDeps = false,
+  includeComponentMetadata = false
 ): Promise<SinglePackageResult> {
   const lockfilePath = path.isAbsolute(targetFile)
     ? targetFile
@@ -32,7 +33,8 @@ export async function getPoetryDependencies(
     const dependencyGraph = poetry.buildDepGraph(
       manifestContents,
       lockfileContents,
-      includeDevDeps
+      includeDevDeps,
+      includeComponentMetadata
     );
     const plugin = await getMetaData(command, [], root, targetFile);
     return {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@snyk/dep-graph": "^1.28.1",
     "@snyk/error-catalog-nodejs-public": "^5.77.0",
     "shescape": "2.1.6",
-    "snyk-poetry-lockfile-parser": "1.9.2",
+    "snyk-poetry-lockfile-parser": "1.10.0",
     "tmp": "0.2.7"
   },
   "devDependencies": {

--- a/test/unit/poetry.spec.ts
+++ b/test/unit/poetry.spec.ts
@@ -42,6 +42,74 @@ describe('getPoetryDepencies', () => {
     expect(poetry.buildDepGraph).toHaveBeenCalledTimes(1);
   });
 
+  it('threads includeComponentMetadata=false through to buildDepGraph by default', async () => {
+    jest.spyOn(poetry, 'buildDepGraph').mockReturnValue(mockDepGraph as any);
+    jest.spyOn(inspectImpl, 'getMetaData').mockResolvedValue(mockPlugin as any);
+
+    await getPoetryDependencies(
+      'python',
+      '/some/bogus/root',
+      path.join(POETRY_APP_ROOT, FILENAMES.poetry.lockfile)
+    );
+
+    expect(poetry.buildDepGraph).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      false,
+      false
+    );
+  });
+
+  it('threads includeComponentMetadata=true through to buildDepGraph', async () => {
+    jest.spyOn(poetry, 'buildDepGraph').mockReturnValue(mockDepGraph as any);
+    jest.spyOn(inspectImpl, 'getMetaData').mockResolvedValue(mockPlugin as any);
+
+    await getPoetryDependencies(
+      'python',
+      '/some/bogus/root',
+      path.join(POETRY_APP_ROOT, FILENAMES.poetry.lockfile),
+      false,
+      true
+    );
+
+    expect(poetry.buildDepGraph).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      false,
+      true
+    );
+  });
+
+  it('emits hash labels on nodes only when includeComponentMetadata is set (real parser)', async () => {
+    // Do NOT mock buildDepGraph here: exercise the linked parser end-to-end.
+    jest.spyOn(inspectImpl, 'getMetaData').mockResolvedValue(mockPlugin as any);
+    const targetFile = path.join(POETRY_APP_ROOT, FILENAMES.poetry.lockfile);
+
+    const withoutFlag = await getPoetryDependencies(
+      'python',
+      '/some/bogus/root',
+      targetFile,
+      false,
+      false
+    );
+    const withFlag = await getPoetryDependencies(
+      'python',
+      '/some/bogus/root',
+      targetFile,
+      false,
+      true
+    );
+
+    const hashLabels = (result: typeof withFlag): string[] =>
+      result
+        .dependencyGraph!.toJSON()
+        .graph.nodes.map((n) => n.info?.labels?.['hash:sha-256'])
+        .filter((v): v is string => Boolean(v));
+
+    expect(hashLabels(withoutFlag)).toHaveLength(0);
+    expect(hashLabels(withFlag).length).toBeGreaterThan(0);
+  });
+
   it('should throw exception when manifest does not exist', async () => {
     expect.assertions(1);
     const root = 'rootPath';

--- a/test/unit/poetry.spec.ts
+++ b/test/unit/poetry.spec.ts
@@ -100,14 +100,24 @@ describe('getPoetryDepencies', () => {
       true
     );
 
-    const hashLabels = (result: typeof withFlag): string[] =>
+    const labelValues = (result: typeof withFlag, key: string): string[] =>
       result
         .dependencyGraph!.toJSON()
-        .graph.nodes.map((n) => n.info?.labels?.['hash:sha-256'])
+        .graph.nodes.map((n) => n.info?.labels?.[key])
         .filter((v): v is string => Boolean(v));
 
-    expect(hashLabels(withoutFlag)).toHaveLength(0);
-    expect(hashLabels(withFlag).length).toBeGreaterThan(0);
+    expect(labelValues(withoutFlag, 'hash:sha-256')).toHaveLength(0);
+    expect(labelValues(withoutFlag, 'distribution:url')).toHaveLength(0);
+
+    const hashes = labelValues(withFlag, 'hash:sha-256');
+    const urls = labelValues(withFlag, 'distribution:url');
+    expect(hashes.length).toBeGreaterThan(0);
+    // These fixture deps come from PyPI (no [package.source]), so each also gets a
+    // pypi.org project-page URL whose fragment names the file the hash describes.
+    expect(urls.length).toBeGreaterThan(0);
+    for (const url of urls) {
+      expect(url).toMatch(/^https:\/\/pypi\.org\/simple\/[^/]+\/#.+$/);
+    }
   });
 
   it('should throw exception when manifest does not exist', async () => {


### PR DESCRIPTION
- [ ] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Threads a new `includeComponentMetadata` option through to the poetry dep-graph
builder, so poetry projects can emit `hash:<alg>` and `distribution:url` labels
on dep-graph nodes for `sbom-export` to turn into `Component[].Hashes[]` and the
"distribution" `ExternalUrls` entry.

- Adds `includeComponentMetadata?: boolean` to `PythonInspectOptions`.
- `getDependencies` reads it and passes it to `getPoetryDependencies`, which
  forwards it as the 4th arg of `snyk-poetry-lockfile-parser`'s `buildDepGraph`.
- Mirrors the existing `options.dev` → `includeDevDeps` positional threading, so
  the shape should look familiar.

Default-off; nothing changes unless the option is set. Poetry-only — the
installed-deps (pip/pipenv) path is untouched.

#### ⚠️ Blocked on a parser release (what a taker-over needs to do)

This PR deliberately contains **no version bump**. It needs the 4-arg
`buildDepGraph` from snyk-poetry-lockfile-parser:

- Parser PR: https://github.com/snyk/snyk-poetry-lockfile-parser/pull/43

Once that merges and publishes, bump `snyk-poetry-lockfile-parser` in
`package.json` (currently pinned `1.9.2`) to the new version and CI will go
green. **Until then the TypeScript build here will fail** — `1.9.2`'s
`buildDepGraph` only accepts 3 params. That failure is expected and is the only
thing standing between this and mergeable.

#### Where should the reviewer start?

`lib/dependencies/poetry.ts` (the new param + the `buildDepGraph` call) and
`lib/dependencies/index.ts` (option declaration + threading). Both diffs are a
few lines each.

#### How should this be manually tested?

Against a local parser checkout (how it was developed and verified):

```sh
# in a snyk-poetry-lockfile-parser checkout on the PR-43 branch
npm ci && npm run build

# here
npm pkg set dependencies.snyk-poetry-lockfile-parser=file:/abs/path/to/snyk-poetry-lockfile-parser
npm install && npm run build
npx jest test/unit/poetry.spec.ts
```

`test/unit/poetry.spec.ts` covers it three ways: the flag is threaded as
`false` by default and `true` when set (mocked parser), and — with the **real**
parser, no mocks — nodes gain `hash:sha-256` plus a `distribution:url` matching
`https://pypi.org/simple/<name>/#<file>` only when the flag is set. Full suite:
`npx jest test/unit` (18 tests).

Verified end-to-end through a locally-built CLI as well: `snyk test
--print-graph --include-component-metadata --file=poetry.lock` against a poetry
fixture emits e.g.
`"hash:sha-256":"f0a4641d…","distribution:url":"https://pypi.org/simple/jinja2/#Jinja2-2.11.2-py2.py3-none-any.whl"`,
and nothing without the flag.

#### Any background context you want to provide?

The CLI already forwards `--include-component-metadata` into plugin options via
its generic single-plugin path, so **no CLI source change is needed** — only the
acceptance coverage in https://github.com/snyk/cli (PR linked below once open).

Poetry specifics that shaped the parser side (relevant when reading the labels):
`poetry.lock` lists a platform-agnostic *set* of files per package (sdist + every
wheel), so the parser collapses to one artifact — universal wheel → sdist → none
— and the `distribution:url` is a PEP 503 project-page URL whose `#<filename>`
fragment names that same artifact, since the lock never stores a real download
URL. Rationale is written up in the parser PR.

#### What are the relevant tickets?

[CMPA-656](https://snyksec.atlassian.net/browse/CMPA-656)

#### Screenshots

N/A

#### Additional questions

N/A


[CMPA-656]: https://snyksec.atlassian.net/browse/CMPA-656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ