### PR TITLE
fix(deps): bump snyk-poetry-lockfile-parser to 1.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@snyk/dep-graph": "^1.28.1",
     "@snyk/error-catalog-nodejs-public": "^5.77.0",
     "shescape": "2.1.6",
-    "snyk-poetry-lockfile-parser": "1.10.0",
+    "snyk-poetry-lockfile-parser": "1.10.1",
     "tmp": "0.2.7"
   },
   "devDependencies": {


### PR DESCRIPTION
## What does this PR do?

Bumps `snyk-poetry-lockfile-parser` `1.10.0` → `1.10.1`.

1.10.1 tightens the `distribution:url` provenance label emitted for poetry
component metadata: source-URL query strings (which aren't part of an artifact's
identity) are now dropped, and a malformed label for `legacy` index roots that
carried a query string is corrected. See
snyk/snyk-poetry-lockfile-parser#44.

No plugin code change — the poetry path already forwards
`includeComponentMetadata` to the parser; this just picks up the parser's fix.

## Risk

**Low.** Patch bump of a single dependency; the only behavioural change is in the
label string the parser produces. No change to the plugin's own logic or
interfaces.

## Downstream

Once released, bump `snyk-python-plugin` in the Snyk CLI (snyk/cli#7048) to
`^3.3.1` and extend the CLI's poetry provenance acceptance test to the
query-string case.
