### PR TITLE
chore: point SoS vuln alerts at snyk-vuln-alerts-sca-scanners [CMPA-724]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ workflows:
           context:
             - snyk-bot-slack
             - prodsec-orb-runtime
-          channel: snyk-vuln-alerts-sca
+          channel: snyk-vuln-alerts-sca-scanners
           filters:
             branches:
               ignore:


### PR DESCRIPTION
`snyk-vuln-alerts-sca` was never a real Slack channel, so the Snyk-on-Snyk vulnerability
alerts this repo's CircleCI config points at have been going nowhere.

The real channel is `#snyk-vuln-alerts-sca-scanners`. This points the `channel:` parameter
in `.circleci/config.yml` at it.

`chore:` rather than `fix:` is deliberate: the channel is an orb parameter read from the
config at pipeline time, so merging is enough for it to take effect and a release would
only cut a spurious version bump for a CI-only change.

[CMPA-724]

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CMPA-724]: https://snyksec.atlassian.net/browse/CMPA-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Slack channel parameter change with no runtime or security logic modifications.
> 
> **Overview**
> Updates the **`prodsec/secrets-scan`** workflow job in `.circleci/config.yml` so Slack notifications use **`snyk-vuln-alerts-sca-scanners`** instead of **`snyk-vuln-alerts-sca`**. The previous value was not a real channel, so SoS vulnerability alerts from this pipeline were never delivered; merging fixes routing with no application or release impact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62afd66bd8e83af1bd07ca0ea1310251215ac064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->